### PR TITLE
burn/mint liquidity argument consistency

### DIFF
--- a/pallets/xyk/src/lib.rs
+++ b/pallets/xyk/src/lib.rs
@@ -349,7 +349,7 @@ decl_module! {
             let liquidity_asset_id = Self::get_liquidity_asset(first_asset_id, second_asset_id);
 
             //get liquidity_asset_amount corresponding to first_asset_amount
-            let liquidity_asset_amount = first_asset_amount * <assets::Module<T>>::total_supply(liquidity_asset_id) / first_asset_reserve
+            let liquidity_asset_amount = first_asset_amount * <assets::Module<T>>::total_supply(liquidity_asset_id) / first_asset_reserve;
 
             ensure!(
                 <Pools<T>>::contains_key((first_asset_id, second_asset_id)),

--- a/pallets/xyk/src/lib.rs
+++ b/pallets/xyk/src/lib.rs
@@ -337,13 +337,19 @@ decl_module! {
             origin,
             first_asset_id: T::AssetId,
             second_asset_id: T::AssetId,
-            liquidity_asset_amount: T::Balance,
+            first_asset_amount: T::Balance,
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
             let vault = <VaultId<T>>::get();
 
+            let first_asset_reserve = <Pools<T>>::get((first_asset_id, second_asset_id));
+            let second_asset_reserve = <Pools<T>>::get((second_asset_id, first_asset_id));
+
             //get liquidity_asset_id of selected pool
             let liquidity_asset_id = Self::get_liquidity_asset(first_asset_id, second_asset_id);
+
+            //get liquidity_asset_amount corresponding to first_asset_amount
+            let liquidity_asset_amount = first_asset_amount * <assets::Module<T>>::total_supply(liquidity_asset_id) / first_asset_reserve
 
             ensure!(
                 <Pools<T>>::contains_key((first_asset_id, second_asset_id)),
@@ -355,9 +361,6 @@ decl_module! {
                 Error::<T>::NotEnoughAssets,
             );
 
-            let first_asset_reserve = <Pools<T>>::get((first_asset_id, second_asset_id));
-            let second_asset_reserve = <Pools<T>>::get((second_asset_id, first_asset_id));
-            let first_asset_amount = first_asset_reserve * liquidity_asset_amount / <assets::Module<T>>::total_supply(liquidity_asset_id);
             let second_asset_amount = second_asset_reserve * liquidity_asset_amount / <assets::Module<T>>::total_supply(liquidity_asset_id);
 
             <assets::Module<T>>::assets_transfer(

--- a/pallets/xyk/src/tests.rs
+++ b/pallets/xyk/src/tests.rs
@@ -317,7 +317,7 @@ fn burn_W() {
 			Origin::signed(2),
 			0,
 			1,
-			500000,
+			250000,
 		);
 
 		assert_eq!(XykStorage::get_total_issuance(2), 500000); // total liquidity assets
@@ -339,7 +339,7 @@ fn burn_W_other_way() {
 			Origin::signed(2),
 			1,
 			0,
-			500000,
+			250000,
 		);
 
 		assert_eq!(XykStorage::get_total_issuance(2), 500000); // total liquidity assets
@@ -363,7 +363,7 @@ fn burn_N_not_enough_liquidity_asset() {
 				Origin::signed(2),
 				0,
 				1,
-				1500000,
+				600000,
 			),
 			Error::<Test>::NotEnoughAssets,
 		);


### PR DESCRIPTION
modified burn_liquidity to accept first_asset_amount as parameter instead of liquidity_asset_amount