### PR TITLE
replace assets pallet with orml_tokens in xyk pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clear_on_drop"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3378,6 +3387,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "hex-literal",
+ "orml-tokens",
  "pallet-assets",
  "pallet-assets-info",
  "pallet-authorship",
@@ -3849,6 +3859,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "orml-tokens"
+version = "0.3.1"
+dependencies = [
+ "clear_on_drop",
+ "frame-support",
+ "frame-system",
+ "orml-traits",
+ "pallet-elections-phragmen",
+ "pallet-treasury",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "orml-traits"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1894c45ef7dd34390c71ee63189d1bfdb873347982d33c7378a7698d818aba1f"
+dependencies = [
+ "frame-support",
+ "impl-trait-for-tuples",
+ "num-traits",
+ "parity-scale-codec",
+ "serde",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3977,6 +4021,21 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-elections-phragmen"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eea3cf2f885b0a195bbd3abe47f965112331cae5b8b6a81826681c1a2ee6d68"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-npos-elections",
  "sp-runtime",
  "sp-std",
 ]
@@ -4236,6 +4295,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-treasury"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805a91aba6aca050e7a60d3e07070eaa28790d752c2ebbfd5961e1c5c6a95ebd"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "parity-scale-codec",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-verifier"
 version = "0.1.1"
 dependencies = [
@@ -4259,11 +4333,13 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
- "pallet-assets",
+ "orml-tokens",
+ "orml-traits",
  "parity-scale-codec",
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -6619,9 +6695,9 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667775bc50eb214225df18c92e4ec57acc7e2dc78d7d210eb4dd930db1a73995"
+checksum = "9c4d204b1cf8e1d4826804ffbd2edd2c4df385ee3046fa4581f09bc18977ea89"
 dependencies = [
  "integer-sqrt",
  "num-traits",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -4,7 +4,7 @@ use hex_literal::hex;
 use mangata_runtime::{
     AccountId, AssetsInfoConfig, BabeConfig, BalancesConfig, BridgeConfig, BridgedAssetConfig,
     GenesisConfig, GrandpaConfig, SessionConfig, SessionKeys, Signature, StakerStatus,
-    StakingConfig, SudoConfig, SystemConfig, VerifierConfig, WASM_BINARY,
+    StakingConfig, SudoConfig, SystemConfig, TokensConfig, VerifierConfig, WASM_BINARY,
 };
 use sc_service::ChainType;
 use sp_consensus_babe::AuthorityId as BabeId;
@@ -321,6 +321,13 @@ fn testnet_genesis(
                     let (.., asset_id, bridged_asset_id, initial_supply, initial_owner) = x;
                     (asset_id, bridged_asset_id, initial_supply, initial_owner)
                 })
+                .collect(),
+        }),
+        orml_tokens: Some(TokensConfig {
+            endowed_accounts: endowed_accounts
+                .iter()
+                // TODO initialize accounts with Mangata token
+                .flat_map(|_| vec![])
                 .collect(),
         }),
     }

--- a/pallets/assets/src/lib.rs
+++ b/pallets/assets/src/lib.rs
@@ -265,6 +265,7 @@ decl_storage! {
         ///
         /// TWOX-NOTE: `AssetId` is trusted, so this is safe.
         TotalSupply: map hasher(twox_64_concat) T::AssetId => T::Balance;
+
     }
 }
 

--- a/pallets/bridged-asset/src/lib.rs
+++ b/pallets/bridged-asset/src/lib.rs
@@ -42,12 +42,6 @@ use codec::{Decode, Encode};
 use artemis_core::BridgedAssetId;
 use pallet_assets as assets;
 
-// #[cfg(test)]
-// mod mock;
-//
-// #[cfg(test)]
-// mod tests;
-
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
 pub struct AccountData {
     pub free: U256,

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -17,9 +17,13 @@ version = '1.3.4'
 [dependencies]
 frame-support = { default-features = false, version = '2.0.0' }
 frame-system = { default-features = false, version = '2.0.0' }
-pallet-assets = { path = '../assets', default-features = false, version = '2.0.0' }
+orml-tokens = { path = '../tokens', default-features = false, version = '0.3.1' }
 sp-runtime = { default-features = false, version = '2.0.0' }
 sp-core = { default-features = false, version = '2.0.0' }
+
+orml-traits = { version = "0.3.1", default-features = false }
+sp-std = { version = "2.0.0", default-features = false }
+
 
 
 [dev-dependencies]
@@ -32,4 +36,6 @@ std = [
     'codec/std',
     'frame-support/std',
     'frame-system/std',
+    'orml-traits/std',
+    "sp-std/std",
 ]

--- a/pallets/xyk/src/lib.rs
+++ b/pallets/xyk/src/lib.rs
@@ -5,20 +5,32 @@ use frame_support::{
     sp_runtime::ModuleId, weights::Pays, StorageMap,
 };
 use frame_system::ensure_signed;
-use pallet_assets as assets;
 use sp_core::U256;
 // TODO documentation!
 use frame_support::sp_runtime::traits::AccountIdConversion;
 use sp_runtime::traits::{SaturatedConversion, Zero};
+
+use orml_tokens::MultiCurrencyMintable;
+use orml_traits::MultiCurrency;
 
 #[cfg(test)]
 mod mock;
 #[cfg(test)]
 mod tests;
 
-pub trait Trait: assets::Trait {
+use frame_support::debug;
+
+pub trait Trait: frame_system::Trait {
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+    type MultiCurrency: MultiCurrencyMintable<Self::AccountId>;
 }
+
+type BalanceOf<T> =
+    <<T as Trait>::MultiCurrency as MultiCurrency<<T as frame_system::Trait>::AccountId>>::Balance;
+
+type CurrencyIdOf<T> = <<T as Trait>::MultiCurrency as MultiCurrency<
+    <T as frame_system::Trait>::AccountId,
+>>::CurrencyId;
 
 const PALLET_ID: ModuleId = ModuleId(*b"79b14c96");
 
@@ -34,6 +46,8 @@ decl_error! {
         InsufficientInputAmount,
         InsufficientOutputAmount,
         SameAsset,
+        AssetAlreadyExists,
+        AssetDoesNotExists,
     }
 }
 
@@ -41,28 +55,28 @@ decl_event!(
     pub enum Event<T>
     where
         AccountId = <T as frame_system::Trait>::AccountId,
-        Balance = <T as assets::Trait>::Balance,
-        AssetId = <T as assets::Trait>::AssetId,
+        Balance = BalanceOf<T>,
+        CurrencyId = CurrencyIdOf<T>,
     {
         //TODO add trading events
-        PoolCreated(AccountId, AssetId, Balance, AssetId, Balance),
-        AssetsSwapped(AccountId, AssetId, Balance, AssetId, Balance),
+        PoolCreated(AccountId, CurrencyId, Balance, CurrencyId, Balance),
+        AssetsSwapped(AccountId, CurrencyId, Balance, CurrencyId, Balance),
         LiquidityMinted(
             AccountId,
-            AssetId,
+            CurrencyId,
             Balance,
-            AssetId,
+            CurrencyId,
             Balance,
-            AssetId,
+            CurrencyId,
             Balance,
         ),
         LiquidityBurned(
             AccountId,
-            AssetId,
+            CurrencyId,
             Balance,
-            AssetId,
+            CurrencyId,
             Balance,
-            AssetId,
+            CurrencyId,
             Balance,
         ),
     }
@@ -72,13 +86,13 @@ decl_event!(
 decl_storage! {
     trait Store for Module<T: Trait> as XykStorage {
 
-        Pools get(fn asset_pool): map hasher(opaque_blake2_256) (T::AssetId, T::AssetId) => T::Balance;
+        Pools get(fn asset_pool): map hasher(opaque_blake2_256) (CurrencyIdOf<T>, CurrencyIdOf<T>) => BalanceOf<T>;
 
-        LiquidityAssets get(fn liquidity_asset): map hasher(opaque_blake2_256) (T::AssetId, T::AssetId) => T::AssetId;
-
-        LiquidityPools get(fn liquidity_pool): map hasher(opaque_blake2_256) T::AssetId => (T::AssetId, T::AssetId);
+        LiquidityAssets get(fn liquidity_asset): map hasher(opaque_blake2_256) (CurrencyIdOf<T>, CurrencyIdOf<T>) => Option<CurrencyIdOf<T>>;
+        LiquidityPools get(fn liquidity_pool): map hasher(opaque_blake2_256) CurrencyIdOf<T> => Option<(CurrencyIdOf<T>, CurrencyIdOf<T>)>;
 
         Nonce get (fn nonce): u32;
+
     }
 }
 
@@ -91,15 +105,14 @@ decl_module! {
         #[weight = 10_000]
         fn create_pool(
             origin,
-            first_asset_id: T::AssetId,
-            first_asset_amount: T::Balance,
-            second_asset_id: T::AssetId,
-            second_asset_amount: T::Balance
+            first_asset_id: CurrencyIdOf<T>,
+            first_asset_amount: BalanceOf<T>,
+            second_asset_id: CurrencyIdOf<T>,
+            second_asset_amount: BalanceOf<T>
         ) -> DispatchResult {
 
             let sender = ensure_signed(origin)?;
             let vault: T::AccountId  = Self::account_id();
-
 
             ensure!(
                 !first_asset_amount.is_zero() && !second_asset_amount.is_zero(),
@@ -117,12 +130,12 @@ decl_module! {
             );
 
             ensure!(
-                <assets::Module<T>>::balance(first_asset_id, sender.clone()) >= first_asset_amount,
+                T::MultiCurrency::free_balance(first_asset_id, &sender) >= first_asset_amount,
                 Error::<T>::NotEnoughAssets,
             );
 
             ensure!(
-                <assets::Module<T>>::balance(second_asset_id, sender.clone()) >= second_asset_amount,
+                T::MultiCurrency::free_balance(second_asset_id, &sender) >= second_asset_amount,
                 Error::<T>::NotEnoughAssets,
             );
 
@@ -139,47 +152,47 @@ decl_module! {
                 (second_asset_id, first_asset_id), second_asset_amount
             );
 
-            let liquidity_asset_id = <assets::Module<T>>::assets_next_asset_id();
+            let initial_liquidity = first_asset_amount + second_asset_amount;
+
+            let liquidity_asset_id = T::MultiCurrency::issue(&sender, initial_liquidity);
 
             <LiquidityAssets<T>>::insert((first_asset_id, second_asset_id), liquidity_asset_id);
             <LiquidityPools<T>>::insert(liquidity_asset_id, (first_asset_id, second_asset_id));
 
-            let initial_liquidity = first_asset_amount + second_asset_amount;
-            <assets::Module<T>>::assets_issue(
+            T::MultiCurrency::transfer(
+                first_asset_id,
                 &sender,
-                &initial_liquidity
-            );
+                &vault,
+                first_asset_amount
+            )?;
 
-            <assets::Module<T>>::assets_transfer(
-                &first_asset_id,
+            T::MultiCurrency::transfer(
+                second_asset_id,
                 &sender,
                 &vault,
-                &first_asset_amount
+                second_asset_amount
             )?;
-            <assets::Module<T>>::assets_transfer(
-                &second_asset_id,
-                &sender,
-                &vault,
-                &second_asset_amount
-            )?;
+
 
             Self::deposit_event(RawEvent::PoolCreated(sender, first_asset_id, first_asset_amount, second_asset_id, second_asset_amount));
 
             Ok(())
+
         }
 
         // you will sell your sold_asset_amount of sold_asset_id to get some amount of bought_asset_id
         #[weight = (10_000, Pays::No)]
         fn sell_asset (
             origin,
-            sold_asset_id: T::AssetId,
-            bought_asset_id: T::AssetId,
-            sold_asset_amount: T::Balance,
-            min_amount_out: T::Balance,
+            sold_asset_id: CurrencyIdOf<T>,
+            bought_asset_id: CurrencyIdOf<T>,
+            sold_asset_amount: BalanceOf<T>,
+            min_amount_out: BalanceOf<T>,
         ) -> DispatchResult {
 
             let sender = ensure_signed(origin)?;
 
+            debug::native::error!("hwllo world");
             ensure!(
                 <Pools<T>>::contains_key((sold_asset_id,bought_asset_id)),
                 Error::<T>::NoSuchPool,
@@ -199,7 +212,7 @@ decl_module! {
             );
 
             ensure!(
-                <assets::Module<T>>::balance(sold_asset_id, sender.clone()) >= sold_asset_amount,
+                T::MultiCurrency::free_balance(sold_asset_id, &sender) >= sold_asset_amount,
                 Error::<T>::NotEnoughAssets,
             );
 
@@ -210,17 +223,17 @@ decl_module! {
 
             let vault = Self::account_id();
 
-            <assets::Module<T>>::assets_transfer(
-                &sold_asset_id,
+            T::MultiCurrency::transfer(
+                sold_asset_id,
                 &sender,
                 &vault,
-                &sold_asset_amount,
+                sold_asset_amount,
             )?;
-            <assets::Module<T>>::assets_transfer(
-                &bought_asset_id,
+            T::MultiCurrency::transfer(
+                bought_asset_id,
                 &vault,
                 &sender,
-                &bought_asset_amount,
+                bought_asset_amount,
             )?;
 
             <Pools<T>>::insert(
@@ -240,10 +253,10 @@ decl_module! {
         #[weight = (10_000, Pays::No)]
         fn buy_asset (
             origin,
-            sold_asset_id: T::AssetId,
-            bought_asset_id: T::AssetId,
-            bought_asset_amount: T::Balance,
-            max_amount_in: T::Balance,
+            sold_asset_id: CurrencyIdOf<T>,
+            bought_asset_id: CurrencyIdOf<T>,
+            bought_asset_amount: BalanceOf<T>,
+            max_amount_in: BalanceOf<T>,
         ) -> DispatchResult {
 
             let sender = ensure_signed(origin)?;
@@ -273,7 +286,7 @@ decl_module! {
             );
 
             ensure!(
-                <assets::Module<T>>::balance(sold_asset_id, sender.clone()) >= sold_asset_amount,
+                T::MultiCurrency::free_balance(sold_asset_id, &sender) >= sold_asset_amount,
                 Error::<T>::NotEnoughAssets,
             );
 
@@ -284,17 +297,17 @@ decl_module! {
 
             let vault = Self::account_id();
 
-            <assets::Module<T>>::assets_transfer(
-                &sold_asset_id,
+            T::MultiCurrency::transfer(
+                sold_asset_id,
                 &sender,
                 &vault,
-                &sold_asset_amount,
+                sold_asset_amount,
             )?;
-            <assets::Module<T>>::assets_transfer(
-                &bought_asset_id,
+            T::MultiCurrency::transfer(
+                bought_asset_id,
                 &vault,
                 &sender,
-                &bought_asset_amount,
+                bought_asset_amount,
             )?;
 
             <Pools<T>>::insert(
@@ -314,15 +327,19 @@ decl_module! {
         #[weight = 10_000]
         fn mint_liquidity (
             origin,
-            first_asset_id: T::AssetId,
-            second_asset_id: T::AssetId,
-            first_asset_amount: T::Balance,
+            first_asset_id: CurrencyIdOf<T>,
+            second_asset_id: CurrencyIdOf<T>,
+            first_asset_amount: BalanceOf<T>,
         ) -> DispatchResult {
 
             let sender = ensure_signed(origin)?;
             let vault = Self::account_id();
 
-            //get liquidity_asset_id of selected pool
+            ensure!(
+                (<LiquidityAssets<T>>::contains_key((first_asset_id, second_asset_id)) || <LiquidityAssets<T>>::contains_key((second_asset_id, first_asset_id))),
+                Error::<T>::NoSuchPool,
+            );
+
             let liquidity_asset_id = Self::get_liquidity_asset(
                  first_asset_id,
                  second_asset_id
@@ -335,7 +352,7 @@ decl_module! {
 
             let first_asset_reserve = <Pools<T>>::get((first_asset_id, second_asset_id));
             let second_asset_reserve = <Pools<T>>::get((second_asset_id, first_asset_id));
-            let total_liquidity_assets = <assets::Module<T>>::total_supply(liquidity_asset_id);
+            let total_liquidity_assets = T::MultiCurrency::total_issuance(liquidity_asset_id);
 
             let first_asset_amount_u256: U256 = first_asset_amount.saturated_into::<u128>().into();
             let first_asset_reserve_u256: U256 = first_asset_reserve.saturated_into::<u128>().into();
@@ -346,9 +363,9 @@ decl_module! {
             let liquidity_assets_minted_u256: U256 = first_asset_amount_u256 * total_liquidity_assets_u256 / first_asset_reserve_u256;
 
             let second_asset_amount = second_asset_amount_u256.saturated_into::<u128>()
-                .saturated_into::<T::Balance>();
+                .saturated_into::<BalanceOf<T>>();
             let liquidity_assets_minted = liquidity_assets_minted_u256.saturated_into::<u128>()
-                .saturated_into::<T::Balance>();
+                .saturated_into::<BalanceOf<T>>();
 
             ensure!(
                 !first_asset_amount.is_zero() && !second_asset_amount.is_zero(),
@@ -356,26 +373,26 @@ decl_module! {
             );
 
             ensure!(
-                <assets::Module<T>>::balance(first_asset_id, sender.clone()) >= first_asset_amount,
+                T::MultiCurrency::free_balance(first_asset_id, &sender) >= first_asset_amount,
                 Error::<T>::NotEnoughAssets,
             );
 
             ensure!(
-                <assets::Module<T>>::balance(second_asset_id, sender.clone()) >= second_asset_amount,
+                T::MultiCurrency::free_balance(second_asset_id, &sender) >= second_asset_amount,
                 Error::<T>::NotEnoughAssets,
             );
 
-            <assets::Module<T>>::assets_transfer(
-                &first_asset_id,
+            T::MultiCurrency::transfer(
+                first_asset_id,
                 &sender,
                 &vault,
-                &first_asset_amount,
+                first_asset_amount,
             )?;
-            <assets::Module<T>>::assets_transfer(
-                &second_asset_id,
+            T::MultiCurrency::transfer(
+                second_asset_id,
                 &sender,
                 &vault,
-                &second_asset_amount,
+                second_asset_amount,
             )?;
 
             <Pools<T>>::insert(
@@ -387,14 +404,15 @@ decl_module! {
                 second_asset_reserve + second_asset_amount,
             );
 
-            <assets::Module<T>>::assets_mint(
-                &liquidity_asset_id,
+            ensure!(
+                 T::MultiCurrency::mint(
+                liquidity_asset_id,
                 &sender,
-                &liquidity_assets_minted
-            )?;
+                liquidity_assets_minted).is_ok(),
+                Error::<T>::AssetDoesNotExists);
 
-            Self::deposit_event(RawEvent::LiquidityMinted(sender,first_asset_id, first_asset_amount, second_asset_id, second_asset_amount,liquidity_asset_id, second_asset_amount));
-          //  Self::deposit_event(RawEvent::LiquidityAssetsGained(sender.clone(),liquidity_asset_id, second_asset_amount));
+           Self::deposit_event(RawEvent::LiquidityMinted(sender,first_asset_id, first_asset_amount, second_asset_id, second_asset_amount,liquidity_asset_id, second_asset_amount));
+        //    Self::deposit_event(RawEvent::LiquidityAssetsGained(sender.clone(),liquidity_asset_id, second_asset_amount));
 
             Ok(())
         }
@@ -402,9 +420,9 @@ decl_module! {
         #[weight = 10_000]
         fn burn_liquidity (
             origin,
-            first_asset_id: T::AssetId,
-            second_asset_id: T::AssetId,
-            liquidity_asset_amount: T::Balance,
+            first_asset_id: CurrencyIdOf<T>,
+            second_asset_id: CurrencyIdOf<T>,
+            liquidity_asset_amount: BalanceOf<T>,
         ) -> DispatchResult {
 
             let sender = ensure_signed(origin)?;
@@ -420,7 +438,7 @@ decl_module! {
             let liquidity_asset_id = Self::get_liquidity_asset(first_asset_id, second_asset_id);
 
             ensure!(
-                <assets::Module<T>>::balance(liquidity_asset_id, sender.clone()) >= liquidity_asset_amount,
+                T::MultiCurrency::free_balance(liquidity_asset_id, &sender) >= liquidity_asset_amount,
                 Error::<T>::NotEnoughAssets,
             );
 
@@ -431,17 +449,17 @@ decl_module! {
                 Error::<T>::ZeroAmount,
             );
 
-            <assets::Module<T>>::assets_transfer(
-                &first_asset_id,
+            T::MultiCurrency::transfer(
+                first_asset_id,
                 &vault,
                 &sender,
-                &first_asset_amount,
+                first_asset_amount,
             )?;
-            <assets::Module<T>>::assets_transfer(
-                &second_asset_id,
+            T::MultiCurrency::transfer(
+                second_asset_id,
                 &vault,
                 &sender,
-                &second_asset_amount,
+                second_asset_amount,
             )?;
 
             <Pools<T>>::insert(
@@ -453,13 +471,13 @@ decl_module! {
                 second_asset_reserve - second_asset_amount,
             );
 
-            if (first_asset_reserve - first_asset_amount == 0.saturated_into::<T::Balance>())
-                || (second_asset_reserve - second_asset_amount == 0.saturated_into::<T::Balance>()) {
+            if (first_asset_reserve - first_asset_amount == 0.saturated_into::<BalanceOf<T>>())
+                || (second_asset_reserve - second_asset_amount == 0.saturated_into::<BalanceOf<T>>()) {
                 <Pools<T>>::remove((first_asset_id, second_asset_id));
                 <Pools<T>>::remove((second_asset_id, first_asset_id));
             }
 
-            <assets::Module<T>>::assets_burn(&liquidity_asset_id, &sender, &liquidity_asset_amount)?;
+            T::MultiCurrency::slash(liquidity_asset_id, &sender, liquidity_asset_amount);
 
             Self::deposit_event(RawEvent::LiquidityBurned(sender.clone(),first_asset_id, first_asset_amount, second_asset_id, second_asset_amount,liquidity_asset_id, second_asset_amount));
 
@@ -470,10 +488,10 @@ decl_module! {
 
 impl<T: Trait> Module<T> {
     pub fn calculate_sell_price(
-        input_reserve: T::Balance,
-        output_reserve: T::Balance,
-        sell_amount: T::Balance,
-    ) -> T::Balance {
+        input_reserve: BalanceOf<T>,
+        output_reserve: BalanceOf<T>,
+        sell_amount: BalanceOf<T>,
+    ) -> BalanceOf<T> {
         let input_reserve_saturated: U256 = input_reserve.saturated_into::<u128>().into();
         let output_reserve_saturated: U256 = output_reserve.saturated_into::<u128>().into();
         let sell_amount_saturated: U256 = sell_amount.saturated_into::<u128>().into();
@@ -485,14 +503,14 @@ impl<T: Trait> Module<T> {
 
         result
             .saturated_into::<u128>()
-            .saturated_into::<T::Balance>()
+            .saturated_into::<BalanceOf<T>>()
     }
 
     pub fn calculate_buy_price(
-        input_reserve: T::Balance,
-        output_reserve: T::Balance,
-        buy_amount: T::Balance,
-    ) -> T::Balance {
+        input_reserve: BalanceOf<T>,
+        output_reserve: BalanceOf<T>,
+        buy_amount: BalanceOf<T>,
+    ) -> BalanceOf<T> {
         let input_reserve_saturated: U256 = input_reserve.saturated_into::<u128>().into();
         let output_reserve_saturated: U256 = output_reserve.saturated_into::<u128>().into();
         let buy_amount_saturated: U256 = buy_amount.saturated_into::<u128>().into();
@@ -503,25 +521,26 @@ impl<T: Trait> Module<T> {
 
         result
             .saturated_into::<u128>()
-            .saturated_into::<T::Balance>()
+            .saturated_into::<BalanceOf<T>>()
     }
 
     pub fn get_liquidity_asset(
-        first_asset_id: T::AssetId,
-        second_asset_id: T::AssetId,
-    ) -> T::AssetId {
+        first_asset_id: CurrencyIdOf<T>,
+        second_asset_id: CurrencyIdOf<T>,
+    ) -> CurrencyIdOf<T> {
+        //TODO get rid of unwraps
         if <LiquidityAssets<T>>::contains_key((first_asset_id, second_asset_id)) {
-            <LiquidityAssets<T>>::get((first_asset_id, second_asset_id))
+            <LiquidityAssets<T>>::get((first_asset_id, second_asset_id)).unwrap()
         } else {
-            <LiquidityAssets<T>>::get((second_asset_id, first_asset_id))
+            <LiquidityAssets<T>>::get((second_asset_id, first_asset_id)).unwrap()
         }
     }
 
     pub fn get_burn_amount(
-        first_asset_id: T::AssetId,
-        second_asset_id: T::AssetId,
-        liquidity_asset_amount: T::Balance,
-    ) -> (T::Balance, T::Balance) {
+        first_asset_id: CurrencyIdOf<T>,
+        second_asset_id: CurrencyIdOf<T>,
+        liquidity_asset_amount: BalanceOf<T>
+    ) -> (BalanceOf<T>, BalanceOf<T>) {
         let liquidity_asset_id = Self::get_liquidity_asset(first_asset_id, second_asset_id);
         let first_asset_reserve_u256: U256 = <Pools<T>>::get((first_asset_id, second_asset_id))
             .saturated_into::<u128>()
@@ -530,7 +549,7 @@ impl<T: Trait> Module<T> {
             .saturated_into::<u128>()
             .into();
         let total_liquidity_assets_u256: U256 =
-            <assets::Module<T>>::total_supply(liquidity_asset_id)
+            T::MultiCurrency::total_issuance(liquidity_asset_id)
                 .saturated_into::<u128>()
                 .into();
         let liquidity_asset_amount_u256: U256 =
@@ -542,10 +561,10 @@ impl<T: Trait> Module<T> {
             second_asset_reserve_u256 * liquidity_asset_amount_u256 / total_liquidity_assets_u256;
         let second_asset_amount = second_asset_amount_u256
             .saturated_into::<u128>()
-            .saturated_into::<T::Balance>();
+            .saturated_into::<BalanceOf<T>>();
         let first_asset_amount = first_asset_amount_u256
             .saturated_into::<u128>()
-            .saturated_into::<T::Balance>();
+            .saturated_into::<BalanceOf<T>>();
 
         return (first_asset_amount, second_asset_amount);
     }

--- a/pallets/xyk/src/tests.rs
+++ b/pallets/xyk/src/tests.rs
@@ -5,7 +5,6 @@ use super::*;
 use crate::mock::Test;
 use crate::mock::*;
 use frame_support::assert_err;
-use frame_system as system;
 
 //fn create_pool_W(): create_pool working assert (maps,acocounts values)  //DONE
 //fn create_pool_N_already_exists(): create_pool not working if pool already exists  //DONE
@@ -46,13 +45,13 @@ use frame_system as system;
 
 //liquidity assets after trade, after burn, after mint
 
-pub trait Trait: assets::Trait {
-    // TODO: Add other types and constants required configure this module.
-    // type Hashing = BlakeTwo256;
+// pub trait Trait: frame_system::Trait {
+//     // TODO: Add other types and constants required configure this module.
+//     // type Hashing = BlakeTwo256;
 
-    // The overarching event type.
-    type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
-}
+//     // The overarching event type.
+//     type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+// }
 
 // W - should work
 // N - should not work
@@ -61,9 +60,9 @@ fn initialize() {
     // creating asset with assetId 0 and minting to accountId 2
     let acc_id: u64 = 2;
     let amount: u128 = 1000000000000000000000;
+    println!("{}", XykStorage::create_new_token(&acc_id, amount));
+    println!("{}", XykStorage::create_new_token(&acc_id, amount));
 
-    <pallet_assets::Module<Test>>::assets_issue(&acc_id, &amount);
-    <pallet_assets::Module<Test>>::assets_issue(&acc_id, &amount);
     XykStorage::create_pool(
         Origin::signed(2),
         0,
@@ -80,8 +79,8 @@ fn multi() {
         let acc_id: u64 = 2;
         let amount: u128 = 2000000000000000000000000;
 
-        <pallet_assets::Module<Test>>::assets_issue(&acc_id, &amount);
-        <pallet_assets::Module<Test>>::assets_issue(&acc_id, &amount);
+        XykStorage::create_new_token(&acc_id, amount);
+        XykStorage::create_new_token(&acc_id, amount);
         XykStorage::create_pool(
             Origin::signed(2),
             0,
@@ -92,30 +91,18 @@ fn multi() {
         .unwrap();
         assert_eq!(XykStorage::asset_pool((0, 1)), 1000000000000000000000000); // amount of asset 0 in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 500000000000000000000000); // amount of asset 1 in pool map
-        assert_eq!(XykStorage::liquidity_asset((0, 1)), 2); // liquidity assetId corresponding to newly created pool
-        assert_eq!(XykStorage::liquidity_pool(2), (0, 1)); // liquidity assetId corresponding to newly created pool
+        assert_eq!(XykStorage::liquidity_asset((0, 1)), Some(2)); // liquidity assetId corresponding to newly created pool
+        assert_eq!(XykStorage::liquidity_pool(2), Some((0, 1))); // liquidity assetId corresponding to newly created pool
+        assert_eq!(XykStorage::total_supply(2), 1500000000000000000000000); // total liquidity assets
+        assert_eq!(XykStorage::balance(2, 2), 1500000000000000000000000); // amount of liquidity assets owned by user by creating pool / initial minting
+        assert_eq!(XykStorage::balance(0, 2), 1000000000000000000000000); // amount of asset 0 in user acc after creating pool / initial minting
+        assert_eq!(XykStorage::balance(1, 2), 1500000000000000000000000); // amount of asset 1 in user acc after creating pool / initial minting
         assert_eq!(
-            <pallet_assets::Module<Test>>::total_supply(2),
-            1500000000000000000000000
-        ); // total liquidity assets
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(2, 2),
-            1500000000000000000000000
-        ); // amount of liquidity assets owned by user by creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            1000000000000000000000000
-        ); // amount of asset 0 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            1500000000000000000000000
-        ); // amount of asset 1 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             1000000000000000000000000
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             500000000000000000000000
         ); // amount of asset 1 in vault acc after creating pool
 
@@ -123,28 +110,16 @@ fn multi() {
 
         assert_eq!(XykStorage::asset_pool((0, 1)), 1500000000000000000000000); // amount of asset 0 in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 750000000000000000000001); // amount of asset 1 in pool map
+        assert_eq!(XykStorage::total_supply(2), 2250000000000000000000000); // total liquidity assets
+        assert_eq!(XykStorage::balance(2, 2), 2250000000000000000000000); // amount of liquidity assets owned by user by creating pool / initial minting
+        assert_eq!(XykStorage::balance(0, 2), 500000000000000000000000); // amount of asset 0 in user acc after creating pool / initial minting
+        assert_eq!(XykStorage::balance(1, 2), 1249999999999999999999999); // amount of asset 1 in user acc after creating pool / initial minting
         assert_eq!(
-            <pallet_assets::Module<Test>>::total_supply(2),
-            2250000000000000000000000
-        ); // total liquidity assets
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(2, 2),
-            2250000000000000000000000
-        ); // amount of liquidity assets owned by user by creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            500000000000000000000000
-        ); // amount of asset 0 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            1249999999999999999999999
-        ); // amount of asset 1 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             1500000000000000000000000
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             750000000000000000000001
         ); // amount of asset 1 in vault acc after creating pool
 
@@ -152,28 +127,16 @@ fn multi() {
 
         assert_eq!(XykStorage::asset_pool((0, 1)), 1200000000000000000000000); // amount of asset 0 in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 600000000000000000000001); // amount of asset 1 in pool map
+        assert_eq!(XykStorage::total_supply(2), 1800000000000000000000000); // total liquidity assets
+        assert_eq!(XykStorage::balance(2, 2), 1800000000000000000000000); // amount of liquidity assets owned by user by creating pool / initial minting
+        assert_eq!(XykStorage::balance(0, 2), 800000000000000000000000); // amount of asset 0 in user acc after creating pool / initial minting
+        assert_eq!(XykStorage::balance(1, 2), 1399999999999999999999999); // amount of asset 1 in user acc after creating pool / initial minting
         assert_eq!(
-            <pallet_assets::Module<Test>>::total_supply(2),
-            1800000000000000000000000
-        ); // total liquidity assets
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(2, 2),
-            1800000000000000000000000
-        ); // amount of liquidity assets owned by user by creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            800000000000000000000000
-        ); // amount of asset 0 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            1399999999999999999999999
-        ); // amount of asset 1 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             1200000000000000000000000
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             600000000000000000000001
         ); // amount of asset 1 in vault acc after creating pool
 
@@ -181,28 +144,16 @@ fn multi() {
 
         assert_eq!(XykStorage::asset_pool((0, 1)), 900000000000000000000000); // amount of asset 0 in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 450000000000000000000001); // amount of asset 1 in pool map
+        assert_eq!(XykStorage::total_supply(2), 1350000000000000000000000); // total liquidity assets
+        assert_eq!(XykStorage::balance(2, 2), 1350000000000000000000000); // amount of liquidity assets owned by user by creating pool / initial minting
+        assert_eq!(XykStorage::balance(0, 2), 1100000000000000000000000); // amount of asset 0 in user acc after creating pool / initial minting
+        assert_eq!(XykStorage::balance(1, 2), 1549999999999999999999999); // amount of asset 1 in user acc after creating pool / initial minting
         assert_eq!(
-            <pallet_assets::Module<Test>>::total_supply(2),
-            1350000000000000000000000
-        ); // total liquidity assets
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(2, 2),
-            1350000000000000000000000
-        ); // amount of liquidity assets owned by user by creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            1100000000000000000000000
-        ); // amount of asset 0 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            1549999999999999999999999
-        ); // amount of asset 1 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             900000000000000000000000
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             450000000000000000000001
         ); // amount of asset 1 in vault acc after creating pool
 
@@ -210,28 +161,16 @@ fn multi() {
 
         assert_eq!(XykStorage::asset_pool((0, 1)), 1900000000000000000000000); // amount of asset 0 in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 950000000000000000000003); // amount of asset 1 in pool map
+        assert_eq!(XykStorage::total_supply(2), 2850000000000000000000000); // total liquidity assets
+        assert_eq!(XykStorage::balance(2, 2), 2850000000000000000000000); // amount of liquidity assets owned by user by creating pool / initial minting
+        assert_eq!(XykStorage::balance(0, 2), 100000000000000000000000); // amount of asset 0 in user acc after creating pool / initial minting
+        assert_eq!(XykStorage::balance(1, 2), 1049999999999999999999997); // amount of asset 1 in user acc after creating pool / initial minting
         assert_eq!(
-            <pallet_assets::Module<Test>>::total_supply(2),
-            2850000000000000000000000
-        ); // total liquidity assets
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(2, 2),
-            2850000000000000000000000
-        ); // amount of liquidity assets owned by user by creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            100000000000000000000000
-        ); // amount of asset 0 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            1049999999999999999999997
-        ); // amount of asset 1 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             1900000000000000000000000
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             950000000000000000000003
         ); // amount of asset 1 in vault acc after creating pool
     });
@@ -243,30 +182,18 @@ fn create_pool_W() {
         initialize();
         assert_eq!(XykStorage::asset_pool((0, 1)), 40000000000000000000); // amount of asset 0 in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 60000000000000000000); // amount of asset 1 in pool map
-        assert_eq!(XykStorage::liquidity_asset((0, 1)), 2); // liquidity assetId corresponding to newly created pool
-        assert_eq!(XykStorage::liquidity_pool(2), (0, 1)); // liquidity assetId corresponding to newly created pool
+        assert_eq!(XykStorage::liquidity_asset((0, 1)), Some(2)); // liquidity assetId corresponding to newly created pool
+        assert_eq!(XykStorage::liquidity_pool(2), Some((0, 1))); // liquidity assetId corresponding to newly created pool
+        assert_eq!(XykStorage::total_supply(2), 100000000000000000000); // total liquidity assets
+        assert_eq!(XykStorage::balance(2, 2), 100000000000000000000); // amount of liquidity assets owned by user by creating pool / initial minting
+        assert_eq!(XykStorage::balance(0, 2), 960000000000000000000); // amount of asset 0 in user acc after creating pool / initial minting
+        assert_eq!(XykStorage::balance(1, 2), 940000000000000000000); // amount of asset 1 in user acc after creating pool / initial minting
         assert_eq!(
-            <pallet_assets::Module<Test>>::total_supply(2),
-            100000000000000000000
-        ); // total liquidity assets
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(2, 2),
-            100000000000000000000
-        ); // amount of liquidity assets owned by user by creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            960000000000000000000
-        ); // amount of asset 0 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            940000000000000000000
-        ); // amount of asset 1 in user acc after creating pool / initial minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             40000000000000000000
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             60000000000000000000
         ); // amount of asset 1 in vault acc after creating pool
     });
@@ -301,8 +228,8 @@ fn create_pool_N_not_enough_first_asset() {
     new_test_ext().execute_with(|| {
         let acc_id: u64 = 2;
         let amount: u128 = 1000000;
-        <pallet_assets::Module<Test>>::assets_issue(&acc_id, &amount);
-        <pallet_assets::Module<Test>>::assets_issue(&acc_id, &amount);
+        XykStorage::create_new_token(&acc_id, amount);
+        XykStorage::create_new_token(&acc_id, amount);
 
         assert_err!(
             XykStorage::create_pool(Origin::signed(2), 0, 1500000, 1, 500000,),
@@ -316,8 +243,8 @@ fn create_pool_N_not_enough_second_asset() {
     new_test_ext().execute_with(|| {
         let acc_id: u64 = 2;
         let amount: u128 = 1000000;
-        <pallet_assets::Module<Test>>::assets_issue(&acc_id, &amount);
-        <pallet_assets::Module<Test>>::assets_issue(&acc_id, &amount);
+        XykStorage::create_new_token(&acc_id, amount);
+        XykStorage::create_new_token(&acc_id, amount);
 
         assert_err!(
             XykStorage::create_pool(Origin::signed(2), 0, 500000, 1, 1500000,),
@@ -368,30 +295,18 @@ fn sell_W() {
         initialize();
         XykStorage::sell_asset(Origin::signed(2), 0, 1, 20000000000000000000, 0).unwrap(); // selling 20000000000000000000 assetId 0 of pool 0 1
 
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            940000000000000000000
-        ); // amount in user acc after selling
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            959959959959959959959
-        ); // amount in user acc after buying
+        assert_eq!(XykStorage::balance(0, 2), 940000000000000000000); // amount in user acc after selling
+        assert_eq!(XykStorage::balance(1, 2), 959959959959959959959); // amount in user acc after buying
         assert_eq!(XykStorage::asset_pool((0, 1)), 60000000000000000000); // amount of asset 0 in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 40040040040040040041); // amount of asset 1 in pool map
+        assert_eq!(XykStorage::balance(0, 2), 940000000000000000000); // amount of asset 0 on account 2
+        assert_eq!(XykStorage::balance(1, 2), 959959959959959959959); // amount of asset 1 on account 2
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            940000000000000000000
-        ); // amount of asset 0 on account 2
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            959959959959959959959
-        ); // amount of asset 1 on account 2
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             60000000000000000000
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             40040040040040040041
         ); // amount of asset 1 in vault acc after creating pool
     });
@@ -403,30 +318,18 @@ fn sell_W_other_way() {
         initialize();
         XykStorage::sell_asset(Origin::signed(2), 1, 0, 30000000000000000000, 0).unwrap(); // selling 30000000000000000000 assetId 1 of pool 0 1
 
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            973306639973306639973
-        ); // amount of asset 0 in user acc after selling
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            910000000000000000000
-        ); // amount of asset 1 in user acc after buying
+        assert_eq!(XykStorage::balance(0, 2), 973306639973306639973); // amount of asset 0 in user acc after selling
+        assert_eq!(XykStorage::balance(1, 2), 910000000000000000000); // amount of asset 1 in user acc after buying
         assert_eq!(XykStorage::asset_pool((0, 1)), 26693360026693360027); // amount of asset 0 in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 90000000000000000000); // amount of asset 1 in pool map
+        assert_eq!(XykStorage::balance(0, 2), 973306639973306639973); // amount of asset 0 on account 2
+        assert_eq!(XykStorage::balance(1, 2), 910000000000000000000); // amount of asset 1 on account 2
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            973306639973306639973
-        ); // amount of asset 0 on account 2
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            910000000000000000000
-        ); // amount of asset 1 on account 2
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             26693360026693360027
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             90000000000000000000
         ); // amount of asset 1 in vault acc after creating pool
     });
@@ -492,30 +395,18 @@ fn buy_W() {
             3000000000000000000000,
         )
         .unwrap();
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            919879638916750250752
-        ); // amount in user acc after selling
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            970000000000000000000
-        ); // amount in user acc after buying
+        assert_eq!(XykStorage::balance(0, 2), 919879638916750250752); // amount in user acc after selling
+        assert_eq!(XykStorage::balance(1, 2), 970000000000000000000); // amount in user acc after buying
         assert_eq!(XykStorage::asset_pool((0, 1)), 80120361083249749248); // amount in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 30000000000000000000); // amount in pool map
+        assert_eq!(XykStorage::balance(0, 2), 919879638916750250752); // amount of asset 0 on account 2
+        assert_eq!(XykStorage::balance(1, 2), 970000000000000000000); // amount of asset 1 on account 2
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            919879638916750250752
-        ); // amount of asset 0 on account 2
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            970000000000000000000
-        ); // amount of asset 1 on account 2
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             80120361083249749248
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             30000000000000000000
         ); // amount of asset 1 in vault acc after creating pool
     });
@@ -534,30 +425,18 @@ fn buy_W_other_way() {
             3000000000000000000000,
         )
         .unwrap();
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            990000000000000000000
-        ); // amount in user acc after selling
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            759458375125376128385
-        ); // amount in user acc after buying
+        assert_eq!(XykStorage::balance(0, 2), 990000000000000000000); // amount in user acc after selling
+        assert_eq!(XykStorage::balance(1, 2), 759458375125376128385); // amount in user acc after buying
         assert_eq!(XykStorage::asset_pool((0, 1)), 10000000000000000000); // amount in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 240541624874623871615); // amount in pool map
+        assert_eq!(XykStorage::balance(0, 2), 990000000000000000000); // amount of asset 0 on account 2
+        assert_eq!(XykStorage::balance(1, 2), 759458375125376128385); // amount of asset 1 on account 2
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            990000000000000000000
-        ); // amount of asset 0 on account 2
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            759458375125376128385
-        ); // amount of asset 1 on account 2
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             10000000000000000000
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             240541624874623871615
         ); // amount of asset 1 in vault acc after creating pool
     });
@@ -645,30 +524,18 @@ fn mint_W() {
         // minting pool 0 1 with 20000000000000000000 assetId 0
         XykStorage::mint_liquidity(Origin::signed(2), 0, 1, 20000000000000000000).unwrap();
 
-        assert_eq!(
-            <pallet_assets::Module<Test>>::total_supply(2),
-            150000000000000000000
-        ); // total liquidity assets
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(2, 2),
-            150000000000000000000
-        ); // amount of liquidity assets owned by user by creating pool and minting
+        assert_eq!(XykStorage::total_supply(2), 150000000000000000000); // total liquidity assets
+        assert_eq!(XykStorage::balance(2, 2), 150000000000000000000); // amount of liquidity assets owned by user by creating pool and minting
         assert_eq!(XykStorage::asset_pool((0, 1)), 60000000000000000000); // amount in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 90000000000000000001); // amount in pool map
+        assert_eq!(XykStorage::balance(0, 2), 940000000000000000000); // amount of asset 0 in user acc after minting
+        assert_eq!(XykStorage::balance(1, 2), 909999999999999999999); // amount of asset 1 in user acc after minting
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            940000000000000000000
-        ); // amount of asset 0 in user acc after minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            909999999999999999999
-        ); // amount of asset 1 in user acc after minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             60000000000000000000
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             90000000000000000001
         ); // amount of asset 1 in vault acc after creating pool
     });
@@ -681,30 +548,18 @@ fn mint_W_other_way() {
         // minting pool 0 1 with 30000000000000000000 assetId 1
         XykStorage::mint_liquidity(Origin::signed(2), 1, 0, 30000000000000000000).unwrap();
 
-        assert_eq!(
-            <pallet_assets::Module<Test>>::total_supply(2),
-            150000000000000000000
-        ); // total liquidity assets
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(2, 2),
-            150000000000000000000
-        ); // amount of liquidity assets owned by user by creating pool and minting
+        assert_eq!(XykStorage::total_supply(2), 150000000000000000000); // total liquidity assets
+        assert_eq!(XykStorage::balance(2, 2), 150000000000000000000); // amount of liquidity assets owned by user by creating pool and minting
         assert_eq!(XykStorage::asset_pool((0, 1)), 60000000000000000001); // amount in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 90000000000000000000); // amount in pool map
+        assert_eq!(XykStorage::balance(0, 2), 939999999999999999999); // amount of asset 0 in user acc after minting
+        assert_eq!(XykStorage::balance(1, 2), 910000000000000000000); // amount of asset 1 in user acc after minting
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            939999999999999999999
-        ); // amount of asset 0 in user acc after minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            910000000000000000000
-        ); // amount of asset 1 in user acc after minting
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             60000000000000000001
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             90000000000000000000
         ); // amount of asset 1 in vault acc after creating pool
     });
@@ -761,26 +616,17 @@ fn burn_W() {
 
         XykStorage::burn_liquidity(Origin::signed(2), 0, 1, 50000000000000000000).unwrap(); // burning 20000000000000000000 asset 0 of pool 0 1
 
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(2, 2),
-            50000000000000000000
-        ); // amount of liquidity assets owned by user by creating pool and burning
+        assert_eq!(XykStorage::balance(2, 2), 50000000000000000000); // amount of liquidity assets owned by user by creating pool and burning
         assert_eq!(XykStorage::asset_pool((0, 1)), 20000000000000000000); // amount in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 30000000000000000000); // amount in pool map
+        assert_eq!(XykStorage::balance(0, 2), 980000000000000000000); // amount of asset 0 in user acc after burning
+        assert_eq!(XykStorage::balance(1, 2), 970000000000000000000); // amount of asset 1 in user acc after burning
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            980000000000000000000
-        ); // amount of asset 0 in user acc after burning
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            970000000000000000000
-        ); // amount of asset 1 in user acc after burning
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             20000000000000000000
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             30000000000000000000
         ); // amount of asset 1 in vault acc after creating pool
     });
@@ -792,26 +638,17 @@ fn burn_W_other_way() {
         initialize();
         XykStorage::burn_liquidity(Origin::signed(2), 1, 0, 50000000000000000000).unwrap(); // burning 30000000000000000000 asset 1 of pool 0 1
 
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(2, 2),
-            50000000000000000000
-        ); // amount of liquidity assets owned by user by creating pool and burning
+        assert_eq!(XykStorage::balance(2, 2), 50000000000000000000); // amount of liquidity assets owned by user by creating pool and burning
         assert_eq!(XykStorage::asset_pool((0, 1)), 20000000000000000000); // amount in pool map
         assert_eq!(XykStorage::asset_pool((1, 0)), 30000000000000000000); // amount in pool map
+        assert_eq!(XykStorage::balance(0, 2), 980000000000000000000); // amount of asset 0 in user acc after burning
+        assert_eq!(XykStorage::balance(1, 2), 970000000000000000000); // amount of asset 1 in user acc after burning
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, 2),
-            980000000000000000000
-        ); // amount of asset 0 in user acc after burning
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, 2),
-            970000000000000000000
-        ); // amount of asset 1 in user acc after burning
-        assert_eq!(
-            <pallet_assets::Module<Test>>::balance(0, XykStorage::account_id()),
+            XykStorage::balance(0, XykStorage::account_id()),
             20000000000000000000
         ); // amount of asset 0 in vault acc after creating pool
         assert_eq!(
-            <pallet_assets::Module<Test>>::balance(1, XykStorage::account_id()),
+            XykStorage::balance(1, XykStorage::account_id()),
             30000000000000000000
         ); // amount of asset 1 in vault acc after creating pool
     });

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -60,6 +60,7 @@ sp-session = { default-features = false, version = '2.0.0' }
 sp-std = { default-features = false, version = '2.0.0' }
 sp-transaction-pool = { default-features = false, version = '2.0.0' }
 sp-version = { default-features = false, version = '2.0.0' }
+orml-tokens = { path="../pallets/tokens", default-features = false, version = '0.3.1' }
 
 # Snowfork pallets
 
@@ -141,4 +142,5 @@ std = [
     "eth-app/std",
     "erc20-app/std",
     "pallet-assets-info/std",
+    'orml-tokens/std',
 ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,8 +47,10 @@ pub use pallet_timestamp::Call as TimestampCall;
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
 
+pub use orml_tokens;
 pub use pallet_assets;
 pub use pallet_assets_info;
+
 use pallet_session::historical as pallet_session_historical;
 pub use pallet_staking::StakerStatus;
 pub use pallet_xyk;
@@ -430,6 +432,7 @@ impl pallet_assets::Trait for Runtime {
 
 impl pallet_xyk::Trait for Runtime {
     type Event = Event;
+    type MultiCurrency = Tokens;
 }
 
 // Snowfork traits
@@ -466,6 +469,7 @@ parameter_types! {
     pub const MaxLengthDescription: usize = 255;
     pub const MaxDecimals: u32 = 255;
 }
+
 impl pallet_assets_info::Trait for Runtime {
     type Event = Event;
     type MinLengthName = MinLengthName;
@@ -475,6 +479,19 @@ impl pallet_assets_info::Trait for Runtime {
     type MinLengthDescription = MinLengthDescription;
     type MaxLengthDescription = MaxLengthDescription;
     type MaxDecimals = MaxDecimals;
+}
+
+impl orml_tokens::Trait for Runtime {
+    type Event = Event;
+    type Balance = Balance;
+    type Amount = i128;
+    type CurrencyId = u32;
+    type OnReceived = ();
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const GetNativeCurrencyId: u32 = 0;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
@@ -506,6 +523,7 @@ construct_runtime!(
         ETH: eth_app::{Module, Call, Storage, Event<T>},
         ERC20: erc20_app::{Module, Call, Storage, Event<T>},
         AssetsInfo: pallet_assets_info::{Module, Call, Config<T>, Storage, Event<T>},
+        Tokens: orml_tokens::{Module, Storage, Call, Event<T>, Config<T>},
     }
 );
 


### PR DESCRIPTION
#25 should be merged first to remove orml_tokens code from that PR.

Changes:
- replace assets pallet with orml_tokens in xyk pallet
- Make Currency pallet parameter of XYK instead of deriving from it in xyk trait definition 
- MultiCurrencyMintable that provides required `mint` and `issue` funcionality
- unit tests alignment