### PR TITLE
Fix for u128 input/output rpc paramters in XYK pallet API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8947,8 +8947,10 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-blockchain",
+ "sp-core",
  "sp-rpc",
  "sp-runtime",
+ "sp-std",
  "xyk-runtime-api",
 ]
 

--- a/pallets/xyk/rpc/Cargo.toml
+++ b/pallets/xyk/rpc/Cargo.toml
@@ -18,6 +18,8 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 sp-api = { version = '2.0.0', default-features = false }
 sp-blockchain = { version = '2.0.0', default-features = false}
 sp-rpc = { version = '2.0.0', default-features = false}
+sp-core = { version = '2.0.0', default-features = false}
+sp-std = { version = '2.0.0', default-features = false}
 sp-runtime = { version = '2.0.0', default-features = false}
 
 # local packages
@@ -29,6 +31,8 @@ default = ["std"]
 std = [
     "serde",
     "sp-api/std",
+    "sp-core/std",
+    "sp-std/std",
     "sp-runtime/std",
     "xyk-runtime-api/std"
 ]

--- a/pallets/xyk/rpc/src/lib.rs
+++ b/pallets/xyk/rpc/src/lib.rs
@@ -5,10 +5,13 @@ use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
+use sp_core::U256;
+use sp_rpc::number::NumberOrHex;
 use sp_runtime::{
     generic::BlockId,
     traits::{Block as BlockT, MaybeDisplay, MaybeFromStr},
 };
+use sp_std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 pub use xyk_runtime_api::XykApi as XykRuntimeApi;
 use xyk_runtime_api::{RpcAmountsResult, RpcResult};
@@ -75,23 +78,42 @@ impl<C, P> Xyk<C, P> {
     }
 }
 
+trait TryIntoBalance<Balance> {
+    fn try_into_balance(self) -> Result<Balance>;
+}
+
+impl<T: TryFrom<U256>> TryIntoBalance<T> for NumberOrHex {
+    fn try_into_balance(self) -> Result<T> {
+        self.into_u256().try_into().or(Err(RpcError {
+            code: ErrorCode::ServerError(1),
+            message: "Unable to serve the request".into(),
+            data: Some(String::from("input parameter doesnt fit into u128").into()),
+        }))
+    }
+}
+
 impl<C, Block, Balance, TokenId>
-    XykApi<<Block as BlockT>::Hash, Balance, TokenId, RpcResult<Balance>, RpcAmountsResult<Balance>>
-    for Xyk<C, Block>
+    XykApi<
+        <Block as BlockT>::Hash,
+        NumberOrHex,
+        TokenId,
+        RpcResult<Balance>,
+        RpcAmountsResult<Balance>,
+    > for Xyk<C, Block>
 where
     Block: BlockT,
     C: Send + Sync + 'static,
     C: ProvideRuntimeApi<Block>,
     C: HeaderBackend<Block>,
     C::Api: XykRuntimeApi<Block, Balance, TokenId>,
-    Balance: Codec + MaybeDisplay + MaybeFromStr,
+    Balance: Codec + MaybeDisplay + MaybeFromStr + TryFrom<U256>,
     TokenId: Codec + MaybeDisplay + MaybeFromStr,
 {
     fn calculate_sell_price(
         &self,
-        input_reserve: Balance,
-        output_reserve: Balance,
-        sell_amount: Balance,
+        input_reserve: NumberOrHex,
+        output_reserve: NumberOrHex,
+        sell_amount: NumberOrHex,
         at: Option<<Block as BlockT>::Hash>,
     ) -> Result<RpcResult<Balance>> {
         let api = self.client.runtime_api();
@@ -99,8 +121,12 @@ where
             // If the block hash is not supplied assume the best block.
             self.client.info().best_hash));
 
-        let runtime_api_result =
-            api.calculate_sell_price(&at, input_reserve, output_reserve, sell_amount);
+        let runtime_api_result = api.calculate_sell_price(
+            &at,
+            input_reserve.try_into_balance()?,
+            output_reserve.try_into_balance()?,
+            sell_amount.try_into_balance()?,
+        );
         runtime_api_result.map_err(|e| RpcError {
             code: ErrorCode::ServerError(1),
             message: "Unable to serve the request".into(),
@@ -110,9 +136,9 @@ where
 
     fn calculate_buy_price(
         &self,
-        input_reserve: Balance,
-        output_reserve: Balance,
-        buy_amount: Balance,
+        input_reserve: NumberOrHex,
+        output_reserve: NumberOrHex,
+        buy_amount: NumberOrHex,
         at: Option<<Block as BlockT>::Hash>,
     ) -> Result<RpcResult<Balance>> {
         let api = self.client.runtime_api();
@@ -120,8 +146,12 @@ where
             // If the block hash is not supplied assume the best block.
             self.client.info().best_hash));
 
-        let runtime_api_result =
-            api.calculate_buy_price(&at, input_reserve, output_reserve, buy_amount);
+        let runtime_api_result = api.calculate_buy_price(
+            &at,
+            input_reserve.try_into_balance()?,
+            output_reserve.try_into_balance()?,
+            buy_amount.try_into_balance()?,
+        );
         runtime_api_result.map_err(|e| RpcError {
             code: ErrorCode::ServerError(1),
             message: "Unable to serve the request".into(),
@@ -133,7 +163,7 @@ where
         &self,
         sold_token_id: TokenId,
         bought_token_id: TokenId,
-        sell_amount: Balance,
+        sell_amount: NumberOrHex,
         at: Option<<Block as BlockT>::Hash>,
     ) -> Result<RpcResult<Balance>> {
         let api = self.client.runtime_api();
@@ -141,8 +171,12 @@ where
             // If the block hash is not supplied assume the best block.
             self.client.info().best_hash));
 
-        let runtime_api_result =
-            api.calculate_sell_price_id(&at, sold_token_id, bought_token_id, sell_amount);
+        let runtime_api_result = api.calculate_sell_price_id(
+            &at,
+            sold_token_id,
+            bought_token_id,
+            sell_amount.try_into_balance()?,
+        );
         runtime_api_result.map_err(|e| RpcError {
             code: ErrorCode::ServerError(1),
             message: "Unable to serve the request".into(),
@@ -154,7 +188,7 @@ where
         &self,
         sold_token_id: TokenId,
         bought_token_id: TokenId,
-        buy_amount: Balance,
+        buy_amount: NumberOrHex,
         at: Option<<Block as BlockT>::Hash>,
     ) -> Result<RpcResult<Balance>> {
         let api = self.client.runtime_api();
@@ -162,8 +196,12 @@ where
             // If the block hash is not supplied assume the best block.
             self.client.info().best_hash));
 
-        let runtime_api_result =
-            api.calculate_buy_price_id(&at, sold_token_id, bought_token_id, buy_amount);
+        let runtime_api_result = api.calculate_buy_price_id(
+            &at,
+            sold_token_id,
+            bought_token_id,
+            buy_amount.try_into_balance()?,
+        );
         runtime_api_result.map_err(|e| RpcError {
             code: ErrorCode::ServerError(1),
             message: "Unable to serve the request".into(),
@@ -175,7 +213,7 @@ where
         &self,
         first_asset_id: TokenId,
         second_asset_id: TokenId,
-        liquidity_asset_amount: Balance,
+        liquidity_asset_amount: NumberOrHex,
         at: Option<<Block as BlockT>::Hash>,
     ) -> Result<RpcAmountsResult<Balance>> {
         let api = self.client.runtime_api();
@@ -183,8 +221,12 @@ where
             // If the block hash is not supplied assume the best block.
             self.client.info().best_hash));
 
-        let runtime_api_result =
-            api.get_burn_amount(&at, first_asset_id, second_asset_id, liquidity_asset_amount);
+        let runtime_api_result = api.get_burn_amount(
+            &at,
+            first_asset_id,
+            second_asset_id,
+            liquidity_asset_amount.try_into_balance()?,
+        );
         runtime_api_result.map_err(|e| RpcError {
             code: ErrorCode::ServerError(1),
             message: "Unable to serve the request".into(),


### PR DESCRIPTION
Actullay its a workaround for serde<->substrate issues.
Those seems to be fixed in v3.0.0. Trick is to use
NumberOrHex instead of u128 for input RPC api paramters.
NumberOrHex can be converted to u128 for XYK runtime api call
and is already shipped with proper serialization/deserialization
impl. What is more it allows for accepting request in both numerical
and hex/string form"