### PR TITLE
changed initial liquidity

### DIFF
--- a/pallets/xyk/src/lib.rs
+++ b/pallets/xyk/src/lib.rs
@@ -955,9 +955,7 @@ impl<T: Trait> XykFunctionsTrait<T::AccountId> for Module<T> {
         ensure!(first_asset_id != second_asset_id, Error::<T>::SameAsset,);
 
         // Liquidity token amount calculation
-        let initial_liquidity = first_asset_amount
-            .checked_add(second_asset_amount)
-            .ok_or_else(|| DispatchError::from(Error::<T>::MathOverflow))?;
+        let initial_liquidity = first_asset_amount;
 
         Pools::insert((first_asset_id, second_asset_id), first_asset_amount);
 


### PR DESCRIPTION
changed initial liquidity when creating the pool to prevent potential overflow. 

Previously initial liquidity amount = first asset amount + second asset amount.

Potential overflow in first and second asset amount are close to u128 max, overflowing at initial liquidity = ~ u128 max * 2