### PR TITLE
Feature/direct forked dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,11 +12,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
+checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
- "gimli 0.23.0",
+ "gimli 0.22.0",
 ]
 
 [[package]]
@@ -31,14 +31,14 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
 name = "aes"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
+checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
  "aes-soft",
  "aesni",
@@ -47,43 +47,43 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0301c9e9c443494d970a07885e8cf3e587bae8356a1d5abd0999068413f7205f"
+checksum = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
 dependencies = [
  "aead",
  "aes",
  "block-cipher",
  "ghash",
- "subtle 2.3.0",
+ "subtle 2.2.3",
 ]
 
 [[package]]
 name = "aes-soft"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
+checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
 dependencies = [
  "block-cipher",
- "byteorder 1.3.4",
- "opaque-debug 0.3.0",
+ "byteorder 1.4.3",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
+checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
 dependencies = [
  "block-cipher",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.2.19"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29661b60bec623f0586702976ff4d0c9942dcb6723161c2df0eea78455cfedfb"
+checksum = "6f33b5018f120946c1dcf279194f238a9f146725593ead1c08fa47ff22b0b5d3"
 dependencies = [
  "const-random",
 ]
@@ -95,16 +95,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
-name = "ahash"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
-
-[[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
 ]
@@ -140,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.34"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
 name = "approx"
@@ -176,14 +170,14 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "artemis-asset"
 version = "0.1.1"
-source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#5eaeafedf30dbd9a199cdf5a3d5d7375adf083df"
+source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#7eacd4866a4eed8fbc508b59ca0d3eb3595c1fc1"
 dependencies = [
  "artemis-core",
  "frame-support",
@@ -202,7 +196,7 @@ dependencies = [
 [[package]]
 name = "artemis-core"
 version = "0.1.1"
-source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#5eaeafedf30dbd9a199cdf5a3d5d7375adf083df"
+source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#7eacd4866a4eed8fbc508b59ca0d3eb3595c1fc1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -215,7 +209,7 @@ dependencies = [
 [[package]]
 name = "artemis-erc20-app"
 version = "0.1.1"
-source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#5eaeafedf30dbd9a199cdf5a3d5d7375adf083df"
+source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#7eacd4866a4eed8fbc508b59ca0d3eb3595c1fc1"
 dependencies = [
  "artemis-asset",
  "artemis-core",
@@ -239,7 +233,7 @@ dependencies = [
 [[package]]
 name = "artemis-eth-app"
 version = "0.1.1"
-source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#5eaeafedf30dbd9a199cdf5a3d5d7375adf083df"
+source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#7eacd4866a4eed8fbc508b59ca0d3eb3595c1fc1"
 dependencies = [
  "artemis-asset",
  "artemis-core",
@@ -263,7 +257,7 @@ dependencies = [
 [[package]]
 name = "artemis-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#5eaeafedf30dbd9a199cdf5a3d5d7375adf083df"
+source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#7eacd4866a4eed8fbc508b59ca0d3eb3595c1fc1"
 dependencies = [
  "ethabi-decode",
  "ethereum-types",
@@ -300,103 +294,44 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.5.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+checksum = "ee81ba99bee79f3c8ae114ae4baa7eaa326f63447cf2ec65e4393618b63f8770"
 dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "once_cell 1.5.1",
- "vec-arena",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
-dependencies = [
- "async-executor",
- "async-io",
- "futures-lite",
- "num_cpus",
- "once_cell 1.5.1",
-]
-
-[[package]]
-name = "async-io"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a0b2bb8ae20fede194e779150fe283f65a4a08461b496de546ec366b174ad9"
-dependencies = [
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "libc",
- "log",
- "nb-connect",
- "once_cell 1.5.1",
- "parking",
- "polling",
- "vec-arena",
- "waker-fn",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
 ]
 
 [[package]]
 name = "async-std"
-version = "1.7.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e82538bc65a25dbdff70e4c5439d52f068048ab97cdea0acd73f131594caa1"
+checksum = "00d68a33ebc8b57800847d00787307f84a562224a14db069b0acefe4c2abbf5d"
 dependencies = [
- "async-global-executor",
- "async-io",
- "async-mutex",
- "blocking",
- "crossbeam-utils 0.8.0",
+ "async-task",
+ "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite",
- "gloo-timers",
+ "futures-timer 3.0.2",
  "kv-log-macro",
  "log",
  "memchr",
  "num_cpus",
- "once_cell 1.5.1",
+ "once_cell 1.4.0",
  "pin-project-lite",
  "pin-utils",
  "slab",
+ "smol",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "async-task"
-version = "4.0.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-tls"
@@ -404,7 +339,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df097e3f506bec0e1a24f06bb3c962c228f36671de841ff579cb99f371772634"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "rustls",
  "webpki",
  "webpki-roots 0.19.0",
@@ -412,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "caae68055714ff28740f310927e04f2eba76ff580b16fb18ed90073ee71646f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -452,21 +387,21 @@ checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.54"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
+checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.22.0",
+ "object 0.20.0",
  "rustc-demangle",
 ]
 
@@ -494,7 +429,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "serde",
 ]
 
@@ -506,7 +441,7 @@ checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if 0.1.10",
+ "cfg-if",
  "clang-sys",
  "clap",
  "env_logger",
@@ -561,13 +496,15 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.9.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
+checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
 dependencies = [
+ "byte-tools",
+ "byteorder 1.4.3",
  "crypto-mac 0.8.0",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -582,23 +519,23 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.11"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec 0.5.1",
  "constant_time_eq",
 ]
 
 [[package]]
 name = "blake2s_simd"
-version = "0.5.11"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
+checksum = "ab9e07352b829279624ceb7c64adb4f585dacdb81d35cafae81139ccd617cf44"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec 0.5.1",
  "constant_time_eq",
 ]
 
@@ -608,9 +545,9 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "generic-array 0.12.3",
 ]
 
@@ -620,17 +557,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
- "generic-array 0.14.4",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
 name = "block-cipher"
-version = "0.8.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
+checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -643,23 +579,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
 name = "blocking"
-version = "1.0.2"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+checksum = "d2468ff7bf85066b4a3678fede6fe66db31846d753ff0adfbfab2c6a6e81612b"
 dependencies = [
  "async-channel",
- "async-task",
  "atomic-waker",
- "fastrand",
  "futures-lite",
- "once_cell 1.5.1",
+ "once_cell 1.4.0",
+ "parking",
+ "waker-fn",
 ]
 
 [[package]]
@@ -669,16 +599,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
-name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
-
-[[package]]
 name = "bstr"
-version = "0.2.14"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 dependencies = [
  "memchr",
 ]
@@ -709,9 +633,9 @@ checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -719,7 +643,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "either",
  "iovec",
 ]
@@ -744,9 +668,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 dependencies = [
  "jobserver",
 ]
@@ -767,45 +691,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "chacha20"
-version = "0.5.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244fbce0d47e97e8ef2f63b81d5e05882cb518c68531eb33194990d7b7e85845"
+checksum = "086c0f07ac275808b7bf9a39f2fd013aae1498be83632814c8c4e0bd53f2dc58"
 dependencies = [
- "stream-cipher",
+ "stream-cipher 0.4.1",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf18d374d66df0c05cdddd528a7db98f78c28e2519b120855c4f84c5027b1f5"
+checksum = "18b0c90556d8e3fec7cf18d84a2f53d27b21288f2fe481b830fadcf809e48205"
 dependencies = [
  "aead",
  "chacha20",
  "poly1305",
- "stream-cipher",
+ "stream-cipher 0.4.1",
  "zeroize",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
- "libc",
  "num-integer",
  "num-traits",
  "time",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -821,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
  "ansi_term 0.11.0",
  "atty",
@@ -854,18 +770,18 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+checksum = "f83c06aff61f2d899eb87c379df3cbf7876f14471dcab474e0b6dc90ab96c080"
 dependencies = [
  "cache-padded",
 ]
 
 [[package]]
 name = "const-random"
-version = "0.1.11"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dc82c12dc2ee6e1ded861cf7d582b46f66f796d1b6c93fa28b911ead95da02"
+checksum = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
 dependencies = [
  "const-random-macro",
  "proc-macro-hack",
@@ -873,19 +789,13 @@ dependencies = [
 
 [[package]]
 name = "const-random-macro"
-version = "0.1.11"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc757bbb9544aa296c2ae00c679e81f886b37e28e59097defe0cf524306f6685"
+checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
 dependencies = [
- "getrandom 0.2.0",
+ "getrandom",
  "proc-macro-hack",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
 name = "constant_time_eq"
@@ -930,7 +840,7 @@ version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d9badfe36176cb653506091693bc2bb1970c9bddfcd6ec7fac404f7eaec6f38"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
@@ -939,7 +849,7 @@ dependencies = [
  "log",
  "regalloc",
  "serde",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "target-lexicon",
  "thiserror",
 ]
@@ -977,7 +887,7 @@ checksum = "2ef419efb4f94ecc02e5d9fbcc910d2bb7f0040e2de570e63a454f883bc891d6"
 dependencies = [
  "cranelift-codegen",
  "log",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "target-lexicon",
 ]
 
@@ -1009,21 +919,11 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1032,20 +932,9 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
- "crossbeam-epoch 0.8.2",
- "crossbeam-utils 0.7.2",
+ "crossbeam-epoch",
+ "crossbeam-utils",
  "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.0",
- "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -1054,25 +943,11 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
+ "autocfg 1.0.0",
+ "cfg-if",
+ "crossbeam-utils",
  "lazy_static",
  "maybe-uninit",
- "memoffset",
- "scopeguard 1.1.0",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
-dependencies = [
- "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.0",
- "lazy_static",
  "memoffset",
  "scopeguard 1.1.0",
 ]
@@ -1083,8 +958,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
+ "cfg-if",
+ "crossbeam-utils",
  "maybe-uninit",
 ]
 
@@ -1094,20 +969,8 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 1.0.0",
- "const_fn",
+ "autocfg 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -1133,8 +996,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.3.0",
+ "generic-array 0.14.3",
+ "subtle 2.2.3",
 ]
 
 [[package]]
@@ -1162,37 +1025,24 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "digest 0.8.1",
  "rand_core 0.5.1",
- "subtle 2.3.0",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
-dependencies = [
- "byteorder 1.3.4",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle 2.3.0",
+ "subtle 2.2.3",
  "zeroize",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.3.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
+checksum = "72aa14c04dfae8dd7d8a2b1cb7ca2152618cd01336dbfe704b8dcbf8d41dbd69"
 
 [[package]]
 name = "derive_more"
-version = "0.99.11"
+version = "0.99.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
+checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1214,7 +1064,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.4",
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -1223,7 +1073,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "dirs-sys",
 ]
 
@@ -1244,7 +1094,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "quick-error",
 ]
 
@@ -1271,38 +1121,38 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55796afa1b20c2945ca8eabfc421839f2b766619209f1ede813cf2484f31804"
+checksum = "4c53dc3a653e0f64081026e4bf048d48fec9fce90c66e8326ca7292df0ff2d82"
 
 [[package]]
 name = "ed25519"
-version = "1.0.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
+checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
 dependencies = [
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.1"
+version = "1.0.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
 dependencies = [
- "curve25519-dalek 3.0.0",
+ "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.2",
+ "sha2 0.8.2",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "env_logger"
@@ -1334,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
+checksum = "6eab5ee3df98a279d9b316b1af6ac95422127b1290317e6d18c1743c99418b01"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1389,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+checksum = "699d84875f1b72b4da017e6b0f77dfa88c0137f089958a88974d15938cbc2976"
 
 [[package]]
 name = "exit-future"
@@ -1399,16 +1249,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
 ]
 
 [[package]]
 name = "extrinsic-info-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
- "futures 0.3.8",
+ "futures 0.3.5",
  "log",
  "parity-scale-codec",
  "serde",
@@ -1420,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "extrinsic-shuffler"
 version = "0.8.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
  "extrinsic-info-runtime-api",
@@ -1470,27 +1320,24 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.4.0"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
-dependencies = [
- "instant",
-]
+checksum = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
 
 [[package]]
 name = "fdlimit"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4c9e43643f5a3be4ca5b67d26b98031ff9db6806c3440ae32e02e3ceac3f1b"
+checksum = "47bc6e222b8349b2bd0acb85a1d16d22852376b3ceed2a7f09c2692c3d8a78d0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "file-per-thread-logger"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fdbe0d94371f9ce939b555dd342d0686cc4c0cadbcd4b61d70af5ff97eb4126"
+checksum = "8b3937f028664bd0e13df401ba49a4567ccda587420365823242977f06609ed1"
 dependencies = [
  "env_logger",
  "log",
@@ -1503,7 +1350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8feb87a63249689640ac9c011742c33139204e3c134293d3054022276869133b"
 dependencies = [
  "either",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 2.0.2",
  "log",
  "num-traits",
@@ -1517,7 +1364,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "rand 0.7.3",
  "rustc-hex",
  "static_assertions",
@@ -1531,11 +1378,11 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.19"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
  "libz-sys",
@@ -1550,28 +1397,16 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fork-tree"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d7f1c606d158d5af4479f2971f259d8dd262f03f6f7b5b37e92eec7b8de396"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
-name = "form_urlencoded"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
-dependencies = [
- "matches",
- "percent-encoding 2.1.0",
-]
-
-[[package]]
 name = "frame-benchmarking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a5e3fe43568300fdca1c1bfd45ea463a12cca8fbe6172a4f6d58cd54e3fbcc"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1588,9 +1423,8 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337ff68053dc7f7af821bdd241f367c17deb2213cc1b88cda7b856e796b6690"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1608,7 +1442,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "extrinsic-shuffler",
  "frame-support",
@@ -1626,9 +1460,8 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "12.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5640bfcb7111643807c63cd38ecdcc923d3253e525f23ab6b366002bf8ecd5"
+version = "12.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1638,20 +1471,19 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807c32da14bd0e5fb751095335a07938cda6f1488f57d7b0539118e3434980a8"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "bitmask",
  "frame-metadata",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "log",
- "once_cell 1.5.1",
+ "once_cell 1.4.0",
  "parity-scale-codec",
  "paste",
  "serde",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "sp-arithmetic",
  "sp-core",
  "sp-inherents",
@@ -1664,9 +1496,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508dc2eb44a802f1876e3dc97a76aed8f18b993f75f6cb1975cb83cf45a5d981"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1676,9 +1507,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f6d1dd14477123180c47024bcc24c1a624ea8631b4f00080d14089907397f4"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1689,9 +1519,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad38379ecedd632f286c7b94a4b9a15bffb635194de4dbf2b4458bc46cee28f"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1700,9 +1529,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d172404f0e44b867f5fd14465a27f298b8828b53d7a7a555d3759e1dec3c8f0d"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1717,9 +1545,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e3a70ce89455777c5a93c60943e8a404c0be66bd3f53605c4a4e79baa80e91"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1732,9 +1559,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b128f689fd9d497c3a7e881be524a8a1e2d80e2661754add6e36c9dfdcbe373"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1776,15 +1602,15 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.1.30"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
+checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
-version = "0.3.8"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1797,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1816,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
 name = "futures-core-preview"
@@ -1832,7 +1658,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.29",
  "num_cpus",
 ]
 
@@ -1842,21 +1668,21 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdcef58a173af8148b182684c9f2d5250875adbcaff7b5794073894f9d8634a9"
 dependencies = [
- "futures 0.1.30",
- "futures 0.3.8",
+ "futures 0.1.29",
+ "futures 0.3.5",
  "lazy_static",
  "log",
  "parking_lot 0.9.0",
- "pin-project 0.4.27",
+ "pin-project",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "futures-executor"
-version = "0.3.8"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1866,15 +1692,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
+checksum = "180d8fc9819eb48a0c976672fbeea13a73e10999e812bdc9e14644c25ad51d60"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1887,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1899,17 +1725,17 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
 dependencies = [
- "once_cell 1.5.1",
+ "once_cell 1.4.0",
 ]
 
 [[package]]
@@ -1923,14 +1749,18 @@ name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper 0.4.0",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.29",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1938,7 +1768,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1964,9 +1794,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.8",
+ "futures 0.3.5",
  "memchr",
- "pin-project 0.4.27",
+ "pin-project",
 ]
 
 [[package]]
@@ -1974,19 +1804,6 @@ name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
-name = "generator"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "generic-array"
@@ -1999,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
 dependencies = [
  "typenum",
  "version_check",
@@ -2031,24 +1848,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -2073,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.23.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "glob"
@@ -2085,9 +1891,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.6"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+checksum = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -2115,10 +1921,10 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "bytes 0.4.12",
  "fnv",
- "futures 0.1.30",
+ "futures 0.1.29",
  "http 0.1.21",
  "indexmap",
  "log",
@@ -2129,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -2144,7 +1950,6 @@ dependencies = [
  "tokio 0.2.22",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -2168,7 +1973,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "scopeguard 0.3.3",
 ]
 
@@ -2178,27 +1983,18 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 dependencies = [
- "ahash 0.2.19",
+ "ahash 0.2.18",
  "autocfg 0.1.7",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
 dependencies = [
  "ahash 0.3.8",
- "autocfg 1.0.1",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-dependencies = [
- "ahash 0.4.6",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -2212,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
@@ -2287,7 +2083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "http 0.1.21",
  "tokio-buf",
 ]
@@ -2309,12 +2105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
-name = "httpdate"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,7 +2120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "futures-cpupool",
  "h2 0.1.26",
  "http 0.1.21",
@@ -2355,22 +2145,22 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.2.7",
+ "h2 0.2.6",
  "http 0.2.1",
  "http-body 0.3.1",
  "httparse",
- "httpdate",
  "itoa",
- "pin-project 1.0.1",
+ "pin-project",
  "socket2",
+ "time",
  "tokio 0.2.22",
  "tower-service",
  "tracing",
@@ -2386,7 +2176,7 @@ dependencies = [
  "bytes 0.5.6",
  "ct-logs",
  "futures-util",
- "hyper 0.13.9",
+ "hyper 0.13.7",
  "log",
  "rustls",
  "rustls-native-certs",
@@ -2457,32 +2247,26 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
 dependencies = [
- "autocfg 1.0.1",
- "hashbrown 0.9.1",
+ "autocfg 1.0.0",
+ "hashbrown 0.8.1",
  "serde",
 ]
 
 [[package]]
 name = "instant"
-version = "0.1.8"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 
 [[package]]
 name = "integer-sqrt"
-version = "0.1.5"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
-dependencies = [
- "num-traits",
-]
+checksum = "f65877bf7d44897a473350b1046277941cee20b263397e90869c50b6e766088b"
 
 [[package]]
 name = "intervalier"
@@ -2490,7 +2274,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa110ec7b8f493f416eed552740d10e7030ad5f63b2308f82c9608ec2df275"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 2.0.2",
 ]
 
@@ -2550,21 +2334,21 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "15.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489b9c612e60c766f751ab40fcb43cbb55a1e10bb44a9b4307ed510ca598cbd7"
+checksum = "c6f7b1cdf66312002e15682a24430728bd13036c641163c016bc53fb686a7c2d"
 dependencies = [
  "failure",
- "futures 0.1.30",
+ "futures 0.1.29",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
@@ -2575,11 +2359,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "15.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0745a6379e3edc893c84ec203589790774e4247420033e71a76d3ab4687991fa"
+checksum = "f30b12567a31d48588a65b6cf870081e6ba1d7b2ae353977cb9820d512e69c70"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.29",
  "log",
  "serde",
  "serde_derive",
@@ -2588,18 +2372,18 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core-client"
-version = "15.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f764902d7b891344a0acb65625f32f6f7c6db006952143bd650209fbe7d94db"
+checksum = "d175ca0cf77439b5495612bf216c650807d252d665b4b70ab2eebd895a88fac1"
 dependencies = [
  "jsonrpc-client-transports",
 ]
 
 [[package]]
 name = "jsonrpc-derive"
-version = "15.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99a847f9ec7bb52149b2786a17c9cb260d6effc6b8eeb8c16b343a487a7563a3"
+checksum = "c2cc6ea7f785232d9ca8786a44e9fa698f92149dcdc1acc4aa1fc69c4993d79e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2609,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "15.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb5c4513b7b542f42da107942b7b759f27120b5cc894729f88254b28dff44b7"
+checksum = "9996b26c0c7a59626d0ed6c5ec8bf06218e62ce1474bd2849f9b9fd38a0158c0"
 dependencies = [
  "hyper 0.12.35",
  "jsonrpc-core",
@@ -2624,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ipc-server"
-version = "15.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf50e53e4eea8f421a7316c5f63e395f7bc7c4e786a6dc54d76fab6ff7aa7ce7"
+checksum = "b8e8f2278fb2b277175b6e21b23e7ecf30e78daff5ee301d0a2a411d9a821a0a"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -2638,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "15.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639558e0604013be9787ae52f798506ae42bf4220fe587bdc5625871cc8b9c77"
+checksum = "f389c5cd1f3db258a99296892c21047e21ae73ff4c0e2d39650ea86fe994b4c7"
 dependencies = [
  "jsonrpc-core",
  "log",
@@ -2651,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "15.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f1f3990650c033bd8f6bd46deac76d990f9bbfb5f8dc8c4767bf0a00392176"
+checksum = "c623e1895d0d9110cb0ea7736cfff13191ff52335ad33b21bd5c775ea98b27af"
 dependencies = [
  "bytes 0.4.12",
  "globset",
@@ -2667,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "15.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6596fe75209b73a2a75ebe1dce4e60e03b88a2b25e8807b667597f6315150d22"
+checksum = "436a92034d0137ab3e3c64a7a6350b428f31cb4d7d1a89f284bcdbcd98a7bc56"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -2711,7 +2495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0315ef2f688e33844400b31f11c263f2b3dc21d8b9355c6891c5f185fae43f9a"
 dependencies = [
  "parity-util-mem",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
@@ -2740,7 +2524,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "regex",
  "rocksdb",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
@@ -2751,9 +2535,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lazycell"
-version = "1.3.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "leb128"
@@ -2763,9 +2547,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
 
 [[package]]
 name = "libloading"
@@ -2791,7 +2575,7 @@ checksum = "571f5a4604c1a40d75651da141dfde29ad15329f537a779528803297d2220274"
 dependencies = [
  "atomic",
  "bytes 0.5.6",
- "futures 0.3.8",
+ "futures 0.3.5",
  "lazy_static",
  "libp2p-core",
  "libp2p-core-derive",
@@ -2817,8 +2601,8 @@ dependencies = [
  "multihash",
  "parity-multiaddr",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
- "smallvec 1.4.2",
+ "pin-project",
+ "smallvec 1.4.1",
  "wasm-timer",
 ]
 
@@ -2829,11 +2613,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f13ba8c7df0768af2eb391696d562c7de88cc3a35122531aaa6a7d77754d25"
 dependencies = [
  "asn1_der",
- "bs58 0.3.1",
+ "bs58",
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "lazy_static",
  "libsecp256k1",
@@ -2842,14 +2626,14 @@ dependencies = [
  "multistream-select",
  "parity-multiaddr",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "pin-project",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
  "sha2 0.8.2",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "thiserror",
  "unsigned-varint 0.4.0",
  "void",
@@ -2873,7 +2657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74029ae187f35f4b8ddf26b9779a68b340045d708528a103917cdca49a296db5"
 dependencies = [
  "flate2",
- "futures 0.3.8",
+ "futures 0.3.5",
  "libp2p-core",
 ]
 
@@ -2883,7 +2667,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf319822e08dd65c8e060d2354e9f952895bbc433f5706c75ed010c152aee5e"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "libp2p-core",
  "log",
 ]
@@ -2896,13 +2680,13 @@ checksum = "d8a9acb43a3e4a4e413e0c4abe0fa49308df7c6335c88534757b647199cb8a51"
 dependencies = [
  "cuckoofilter",
  "fnv",
- "futures 0.3.8",
+ "futures 0.3.5",
  "libp2p-core",
  "libp2p-swarm",
  "prost",
  "prost-build",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
@@ -2912,10 +2696,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab20fcb60edebe3173bbb708c6ac3444afdf1e3152dc2866b10c4f5497f17467"
 dependencies = [
  "base64 0.11.0",
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures_codec",
  "hex_fmt",
  "libp2p-core",
@@ -2926,7 +2710,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2 0.8.2",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "unsigned-varint 0.4.0",
  "wasm-timer",
 ]
@@ -2937,13 +2721,13 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56396ee63aa9164eacf40c2c5d2bda8c4133c2f57e1b0425d51d3a4e362583b1"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "libp2p-core",
  "libp2p-swarm",
  "log",
  "prost",
  "prost-build",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "wasm-timer",
 ]
 
@@ -2953,11 +2737,11 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc7fa9047f8b8f544278a35c2d9d45d3b2c1785f2d86d4e1629d6edf97be3955"
 dependencies = [
- "arrayvec 0.5.2",
+ "arrayvec 0.5.1",
  "bytes 0.5.6",
  "either",
  "fnv",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures_codec",
  "libp2p-core",
  "libp2p-swarm",
@@ -2967,7 +2751,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2 0.8.2",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "uint",
  "unsigned-varint 0.4.0",
  "void",
@@ -2984,14 +2768,14 @@ dependencies = [
  "data-encoding",
  "dns-parser",
  "either",
- "futures 0.3.8",
+ "futures 0.3.5",
  "lazy_static",
  "libp2p-core",
  "libp2p-swarm",
  "log",
  "net2",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "void",
  "wasm-timer",
 ]
@@ -3004,7 +2788,7 @@ checksum = "8a73a799cc8410b36e40b8f4c4b6babbcb9efd3727111bf517876e4acfa612d3"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures_codec",
  "libp2p-core",
  "log",
@@ -3019,8 +2803,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ef6c490042f549fb1025f2892dfe6083d97a77558f450c1feebe748ca9eb15a"
 dependencies = [
  "bytes 0.5.6",
- "curve25519-dalek 2.1.0",
- "futures 0.3.8",
+ "curve25519-dalek",
+ "futures 0.3.5",
  "lazy_static",
  "libp2p-core",
  "log",
@@ -3030,7 +2814,7 @@ dependencies = [
  "sha2 0.8.2",
  "snow",
  "static_assertions",
- "x25519-dalek 0.6.0",
+ "x25519-dalek",
  "zeroize",
 ]
 
@@ -3040,7 +2824,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad063c21dfcea4518ac9e8bd4119d33a5b26c41e674f602f41f05617a368a5c8"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "libp2p-core",
  "libp2p-swarm",
  "log",
@@ -3056,7 +2840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903a12e99c72dbebefea258de887982adeacc7025baa1ceb10b7fa9928f54791"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures_codec",
  "libp2p-core",
  "log",
@@ -3069,13 +2853,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-pnet"
-version = "0.19.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b3c2d5d26a9500e959a0e19743897239a6c4be78dadf99b70414301a70c006"
+checksum = "37d0db10e139d22d7af0b23ed7949449ec86262798aa0fd01595abdbcb02dc87"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "log",
- "pin-project 0.4.27",
+ "pin-project",
  "rand 0.7.3",
  "salsa20",
  "sha3",
@@ -3089,14 +2873,14 @@ checksum = "9c0c9e8a4cd69d97e9646c54313d007512f411aba8c5226cfcda16df6a6e84a3"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
- "futures 0.3.8",
+ "futures 0.3.5",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "lru 0.6.1",
+ "lru 0.6.0",
  "minicbor",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "unsigned-varint 0.5.1",
  "wasm-timer",
 ]
@@ -3108,11 +2892,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193e444210132237b81b755ec7fe53f1c4bd2f53cf719729b94c0c72eb6eaa1"
 dependencies = [
  "either",
- "futures 0.3.8",
+ "futures 0.3.5",
  "libp2p-core",
  "log",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "void",
  "wasm-timer",
 ]
@@ -3124,7 +2908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f42ec130d7a37a7e47bf4398026b7ad9185c08ed26972e2720f8b94112796f"
 dependencies = [
  "async-std",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "get_if_addrs",
  "ipnet",
@@ -3140,7 +2924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7acb0a034f70d7db94c300eba3f65c0f6298820105624088a9609c9974d77"
 dependencies = [
  "async-std",
- "futures 0.3.8",
+ "futures 0.3.5",
  "libp2p-core",
  "log",
 ]
@@ -3151,7 +2935,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34c1faac6f92c21fbe155417957863ea822fba9e9fd5eb24c0912336a100e63f"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "js-sys",
  "libp2p-core",
  "parity-send-wrapper",
@@ -3167,14 +2951,14 @@ checksum = "d650534ebd99f48f6fa292ed5db10d30df2444943afde4407ceeddab8e513fca"
 dependencies = [
  "async-tls",
  "either",
- "futures 0.3.8",
+ "futures 0.3.5",
  "libp2p-core",
  "log",
  "quicksink",
  "rustls",
  "rw-stream-sink",
  "soketto",
- "url 2.2.0",
+ "url 2.1.1",
  "webpki",
  "webpki-roots 0.18.0",
 ]
@@ -3185,7 +2969,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "781d9b9f043dcdabc40640807125368596b849fd4d96cdca2dcf052fdf6f33fd"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "libp2p-core",
  "parking_lot 0.11.0",
  "thiserror",
@@ -3216,17 +3000,18 @@ dependencies = [
  "hmac-drbg",
  "rand 0.7.3",
  "sha2 0.8.2",
- "subtle 2.3.0",
+ "subtle 2.2.3",
  "typenum",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.2"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3290,20 +3075,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
-dependencies = [
- "cfg-if 0.1.10",
- "generator",
- "scoped-tls",
- "serde",
- "serde_json",
+ "cfg-if",
 ]
 
 [[package]]
@@ -3317,11 +3089,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be716eb6878ca2263eb5d00a781aa13264a794f519fe6af4fbb2668b2d5441c0"
+checksum = "111b945ac72ec09eb7bc62a0fbdc3cc6e80555a7245f52a69d3921a75b53b153"
 dependencies = [
- "hashbrown 0.9.1",
+ "hashbrown 0.8.1",
 ]
 
 [[package]]
@@ -3495,9 +3267,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memmap"
@@ -3511,11 +3283,11 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -3525,7 +3297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f36ddb0b2cdc25d38babba472108798e3477f02be5165f038c5e393e50c57a"
 dependencies = [
  "hash-db",
- "hashbrown 0.8.2",
+ "hashbrown 0.8.1",
  "parity-util-mem",
 ]
 
@@ -3541,7 +3313,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "keccak",
  "rand_core 0.5.1",
  "zeroize",
@@ -3569,12 +3341,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
 ]
 
 [[package]]
@@ -3583,7 +3354,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -3661,37 +3432,37 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "multihash"
-version = "0.11.4"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567122ab6492f49b59def14ecc36e13e64dca4188196dd0cd41f9f3f979f3df6"
+checksum = "f75db05d738947aa5389863aadafbcf2e509d7ba099dc2ddcdf4fc66bf7a9e03"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
- "digest 0.9.0",
- "sha-1 0.9.2",
- "sha2 0.9.2",
+ "digest 0.8.1",
+ "sha-1",
+ "sha2 0.8.2",
  "sha3",
- "unsigned-varint 0.5.1",
+ "unsigned-varint 0.3.3",
 ]
 
 [[package]]
 name = "multimap"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
+checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 
 [[package]]
 name = "multistream-select"
-version = "0.8.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
+checksum = "c9157e87afbc2ef0d84cc0345423d715f445edde00141c93721c162de35a05e5"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.8",
+ "futures 0.3.5",
  "log",
- "pin-project 1.0.1",
- "smallvec 1.4.2",
- "unsigned-varint 0.5.1",
+ "pin-project",
+ "smallvec 1.4.1",
+ "unsigned-varint 0.4.0",
 ]
 
 [[package]]
@@ -3721,22 +3492,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "nb-connect"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "winapi 0.3.9",
 ]
@@ -3749,7 +3510,7 @@ checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "void",
 ]
@@ -3782,7 +3543,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.0.0",
  "num-integer",
  "num-traits",
 ]
@@ -3793,17 +3554,17 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.0.0",
  "num-traits",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.0.0",
  "num-traits",
 ]
 
@@ -3813,7 +3574,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.0.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -3821,11 +3582,11 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.0.0",
  "libm",
 ]
 
@@ -3857,12 +3618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
-
-[[package]]
 name = "once_cell"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3873,11 +3628,11 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.5.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53cef67919d7d247eb9a2f128ca9e522789967ef1eb4ccd8c71a95a8aedf596"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 dependencies = [
- "parking_lot 0.11.0",
+ "parking_lot 0.10.2",
 ]
 
 [[package]]
@@ -3901,7 +3656,7 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 [[package]]
 name = "orml-tokens"
 version = "0.3.1"
-source = "git+https://github.com/mangata-finance/open-runtime-module-library?branch=mangata-dev#c6446b1e77277d10ad4c7181b4fcc1840fe28237"
+source = "git+https://github.com/mangata-finance/open-runtime-module-library?branch=mangata-dev#739644b6f828a21b227a84816eccc05aaa779682"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3917,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "orml-traits"
 version = "0.3.1"
-source = "git+https://github.com/mangata-finance/open-runtime-module-library?branch=mangata-dev#c6446b1e77277d10ad4c7181b4fcc1840fe28237"
+source = "git+https://github.com/mangata-finance/open-runtime-module-library?branch=mangata-dev#739644b6f828a21b227a84816eccc05aaa779682"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -3955,9 +3710,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa683f726db011795ae117683b956e98c061f35f322ad7c0cfe248b6b272ae3"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3972,9 +3726,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b04a80b2d09fcaacaea6190926012348df6ddb225690de098cb8c4cf3fd19b"
+version = "2.0.0"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3988,9 +3741,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e602bfb8c4a6498274c246cd8cd5c3b19b37324a6124542d944d95a3610bd9"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4014,9 +3766,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56bf116724c3adb7eee6ae49adfc28d3d38d9d34bbfdcc009497120256309a37"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4052,9 +3803,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-finality-tracker"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9414e60c78b94ae77ea8ccc4a86e3d5ebd1de93c236d3dd899abacefe5d7e82"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4069,9 +3819,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8a3b81d434ce9ef2c34adf61afa5ecf2a6e386cd626369deda1ca2f7a3b076"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4092,9 +3841,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59762b04bbe918498789a48b9997702027436c3d75ccd640f2d65e592213e3d8"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4109,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "pallet-random-seed"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4125,9 +3873,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-randomness-collective-flip"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b62b8adc02901769b7756b054fa732b6d1aad01e8a2d6873a70fdcd38c59a1"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4139,9 +3886,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abf520fc0c3259be05f164d43d34d52c86aeef8e8c5fded40145394394fc75d"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4205,9 +3951,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13642cbbb2ea520ca2021299baec604de102a1d033dd32812c946cb03f48f47e"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4221,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4239,16 +3984,15 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fe2fc67f2eb123199a5b8fb89a8e1c30e5d6d6b1d98e0330bac85c0d8c46f1"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -4257,9 +4001,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fb0463589eeb1be8a3237e7260d139240e7d113950904f5a3cae5502576078"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4276,9 +4019,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c8b6676df5a4b411a283b9ea22551094710180fa5caebeae9eea8e9dbfa620"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4290,8 +4032,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4306,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "pallet-verifier"
 version = "0.1.1"
-source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#5eaeafedf30dbd9a199cdf5a3d5d7375adf083df"
+source = "git+https://github.com/mangata-finance/snowbridge?branch=mangata-dev#7eacd4866a4eed8fbc508b59ca0d3eb3595c1fc1"
 dependencies = [
  "artemis-core",
  "artemis-ethereum",
@@ -4357,29 +4099,29 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fe99b938abd57507e37f8d4ef30cd74b33c71face2809b37b8beb71bab15ab"
+checksum = "2165a93382a93de55868dcbfa11e4a8f99676a9164eee6a2b4a9479ad319c257"
 dependencies = [
  "arrayref",
- "bs58 0.4.0",
- "byteorder 1.3.4",
+ "bs58",
+ "byteorder 1.4.3",
  "data-encoding",
  "multihash",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
- "unsigned-varint 0.5.1",
- "url 2.2.0",
+ "unsigned-varint 0.4.0",
+ "url 2.1.1",
 ]
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.5"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
+checksum = "34d38aeaffc032ec69faa476b3caaca8d4dd7f3f798137ff30359e5c7869ceb6"
 dependencies = [
- "arrayvec 0.5.2",
+ "arrayvec 0.5.1",
  "bitvec",
  "byte-slice-cast",
  "parity-scale-codec-derive",
@@ -4388,9 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db82bb1c18fc00176004462dd809b2a6d851669550aa17af6dacd21ae0c14"
+checksum = "cd20ff7e0399b274a5f5bb37b712fccb5b3a64b9128200d1c3cc40fe709cb073"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4411,7 +4153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e57fea504fea33f9fbb5f49f378359030e7e026a6ab849bb9e8f0787376f1bf"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "libc",
  "log",
  "mio-named-pipes",
@@ -4429,13 +4171,13 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297ff91fa36aec49ce183484b102f6b75b46776822bd81525bfc4cc9b0dd0f5c"
 dependencies = [
- "cfg-if 0.1.10",
- "hashbrown 0.8.2",
+ "cfg-if",
+ "hashbrown 0.8.1",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "primitive-types",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "winapi 0.3.9",
 ]
 
@@ -4462,23 +4204,23 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e02a625dd75084c2a7024f07c575b61b782f729d18702dabb3cdbf31911dc61"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "bytes 0.4.12",
  "httparse",
  "log",
  "mio",
  "mio-extras",
  "rand 0.7.3",
- "sha-1 0.8.2",
+ "sha-1",
  "slab",
- "url 2.2.0",
+ "url 2.1.1",
 ]
 
 [[package]]
 name = "parking"
-version = "2.0.0"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+checksum = "50d4a6da31f8144a32532fe38fe8fb439a6842e0ec633f0037f0144c14e7f907"
 
 [[package]]
 name = "parking_lot"
@@ -4541,7 +4283,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
@@ -4556,11 +4298,11 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "winapi 0.3.9",
 ]
 
@@ -4570,12 +4312,12 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "cloudabi 0.1.0",
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "winapi 0.3.9",
 ]
 
@@ -4604,7 +4346,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "crypto-mac 0.7.0",
  "rayon",
 ]
@@ -4645,38 +4387,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
 dependencies = [
- "pin-project-internal 0.4.27",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
-dependencies = [
- "pin-project-internal 1.0.1",
+ "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4685,9 +4407,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
 
 [[package]]
 name = "pin-utils"
@@ -4697,9 +4419,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "platforms"
@@ -4708,42 +4430,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 
 [[package]]
-name = "polling"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "log",
- "wepoll-sys",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "poly1305"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce46de8e53ee414ca4d02bfefac75d8c12fba948b76622a40b4be34dfce980"
+checksum = "d9b42192ab143ed7619bf888a7f9c6733a9a2153b218e2cd557cfdb52fbf9bb1"
 dependencies = [
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5884790f1ce3553ad55fec37b5aaac5882e0e845a2612df744d6c85c9bf046c"
+checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "universal-hash",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "primitive-types"
@@ -4769,9 +4478,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -4782,20 +4491,22 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+ "syn-mid",
  "version_check",
 ]
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
@@ -4818,7 +4529,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d70cf4412832bcac9cffe27906f4a66e450d323525e977168c70d1b36120ae"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "fnv",
  "lazy_static",
  "parking_lot 0.11.0",
@@ -4883,7 +4594,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f53bc2558e8376358ebdc28301546471d67336584f6438ed4b7c7457a055fd7"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "log",
  "parity-wasm",
 ]
@@ -4981,7 +4692,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -5030,7 +4741,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
 ]
 
 [[package]]
@@ -5116,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "random-seed-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "pallet-random-seed",
  "sp-api",
@@ -5141,25 +4852,25 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "62f02856753d04e03e26929f820d0a0a337ebe71f849801eea335d464b349080"
 dependencies = [
- "autocfg 1.0.1",
- "crossbeam-deque 0.8.0",
+ "autocfg 1.0.0",
+ "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "e92e15d89083484e11353891f1af602cc661426deb9564c298b270c726973280"
 dependencies = [
- "crossbeam-channel",
- "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.0",
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -5181,29 +4892,29 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_users"
-version = "0.3.5"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
  "redox_syscall",
  "rust-argon2",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17626b2f4bcf35b84bf379072a66e28cfe5c3c6ae58b38e4914bb8891dabece"
+checksum = "745c1787167ddae5569661d5ffb8b25ae5fedbf46717eaa92d652221cec72623"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c523ccaed8ac4b0288948849a350b37d3035827413c458b6a40ddb614bb4f72"
+checksum = "7d21b475ab879ef0e315ad99067fa25778c3b0377f57f1b00207448dac1a3144"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5218,14 +4929,14 @@ checksum = "b9ba8aaf5fe7cf307c6dbdaeed85478961d29e25e3bee5169e11b92fa9f027a8"
 dependencies = [
  "log",
  "rustc-hash",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5239,15 +4950,15 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "region"
@@ -5284,7 +4995,7 @@ checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
 dependencies = [
  "cc",
  "libc",
- "once_cell 1.5.1",
+ "once_cell 1.4.0",
  "spin",
  "untrusted",
  "web-sys",
@@ -5293,9 +5004,9 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.4.6"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
+checksum = "4a7d3f9bed94764eac15b8f14af59fac420c236adaff743b7bcc88e265cb4345"
 dependencies = [
  "rustc-hex",
 ]
@@ -5322,21 +5033,21 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustc-hash"
@@ -5361,9 +5072,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.18.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
+checksum = "cac94b333ee2aac3284c5b8a1b7fb4dd11cba88c244e3fe33cdbd047af0eb693"
 dependencies = [
  "base64 0.12.3",
  "log",
@@ -5390,8 +5101,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.8",
- "pin-project 0.4.27",
+ "futures 0.3.5",
+ "pin-project",
  "static_assertions",
 ]
 
@@ -5412,23 +5123,33 @@ dependencies = [
 
 [[package]]
 name = "salsa20"
-version = "0.6.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f47b10fa80f6969bbbd9c8e7cc998f082979d402a9e10579e2303a87955395"
+checksum = "2324b0e8c3bb9a586a571fdb3136f70e7e2c748de00a78043f86e0cff91f91fe"
 dependencies = [
- "stream-cipher",
+ "byteorder 1.4.3",
+ "salsa20-core",
+ "stream-cipher 0.3.2",
+]
+
+[[package]]
+name = "salsa20-core"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe6cc1b9f5a5867853ade63099de70f042f7679e408d1ffe52821c9248e6e69"
+dependencies = [
+ "stream-cipher 0.3.2",
 ]
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e38e4486f8cb4c7df9679b4bdab94d51c3bd107568a75922baa31a54844c47c"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "bytes 0.5.6",
  "derive_more",
  "either",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -5451,10 +5172,10 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "extrinsic-info-runtime-api",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5477,7 +5198,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "extrinsic-info-runtime-api",
  "extrinsic-shuffler",
@@ -5501,9 +5222,8 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d0e4d53e723ee6bad8cadec9651086887d1d920996e1589ee7dfa767a7cba9"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5519,9 +5239,8 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af2ca789e2d2fa2aa0ec16d27dc648fa4d64ecb10760d2f552b2c86ea7a403"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5531,9 +5250,8 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2ce2952f155bd72b85ff866c588b6bae8f1bc183275f1a7a54eee55535a640"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5541,7 +5259,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "fdlimit",
- "futures 0.3.8",
+ "futures 0.3.5",
  "hex",
  "lazy_static",
  "libp2p",
@@ -5581,13 +5299,12 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fafb2b2861e847657c4656d2ae2249c9f3f6a76fb92a22f750325b77e1fb4c8"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
  "fnv",
- "futures 0.3.8",
+ "futures 0.3.5",
  "hash-db",
  "hex-literal",
  "kvdb",
@@ -5618,9 +5335,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc82e81fafb162ceda7635932c8b5d65b8bc7b021e49546ab913e2e2458524d"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5649,9 +5365,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6dd5b4e7a37bf78e85161bd6f01a09f0eb7cf49f2961d136885659ad6e30d49"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5662,12 +5377,12 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
  "extrinsic-shuffler",
  "fork-tree",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "log",
  "merlin",
@@ -5709,9 +5424,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f890c5e6c1dbb34d3e0bfde9242b1bf88dc44afee8746d0fa4a91e8e046f21dd"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5723,11 +5437,10 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a334a099d5cac9054ea1ef1db4be8ed5518270027798f96d2a68c5bf69af8e"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
@@ -5747,9 +5460,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-uncles"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050ab17e248045000374952fa91b4ccc82d4da1ee615fb408d744802084cb2d7"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "log",
  "sc-client-api",
@@ -5762,9 +5474,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af77c7fda9659559e257fe330af26e7c2e8f61583c2a5c45f4c9db73d58a902b"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5791,9 +5502,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6663e4d1d2f8255e6c1994ce548365a7631a82f7ab231d0b8a122cc2a0011949"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
  "log",
@@ -5809,9 +5519,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78aeea37a28b83af11fe621ee047758e125341db96efaf7f553a4180fe48d6b8"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5825,9 +5534,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c7d29c1932c5c3281d5324ead624709c1798031df72908ce6012b3651dea0a"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5844,19 +5552,18 @@ dependencies = [
 
 [[package]]
 name = "sc-finality-grandpa"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4095b26b5717265d3dca8e2d70f977dfd4085f1c352dbf82217953da90a96e46"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "pin-project",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
@@ -5882,12 +5589,11 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b81dbdbba0420bb4c0bf2a79bcbb78de5bd1349aad8467b3115f82be579b2972"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "ansi_term 0.12.1",
- "futures 0.3.8",
+ "futures 0.3.5",
  "log",
  "parity-util-mem",
  "sc-client-api",
@@ -5901,9 +5607,8 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bbf8b58ed80e1d375aaa8ee5dedf17f68fea30c900440a695fb630a1757283"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
  "hex",
@@ -5913,14 +5618,13 @@ dependencies = [
  "serde_json",
  "sp-application-crypto",
  "sp-core",
- "subtle 2.3.0",
+ "subtle 2.2.3",
 ]
 
 [[package]]
 name = "sc-light"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00ce4c6f21d572549b8b8a55757a0e548ddd670ab89d9415125a4e09c0ffa74"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5939,20 +5643,19 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e41944816f2543f1a350576325b2f43937589df99911440b41edd85accbe793"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "async-std",
  "async-trait",
  "bitflags",
- "bs58 0.3.1",
+ "bs58",
  "bytes 0.5.6",
  "derive_more",
  "either",
  "erased-serde",
  "fnv",
  "fork-tree",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "futures_codec",
  "hex",
@@ -5965,7 +5668,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "pin-project",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -5993,11 +5696,10 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ddb2a1cb6cd53b46e76f61c662d1561da4a7dc16a375c37849fd1f429b6803"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -6009,15 +5711,14 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79495bd858351489fcebeb4e47821e15329ad5606f0d7983836e069005c3d9dd"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
- "hyper 0.13.9",
+ "hyper 0.13.7",
  "hyper-rustls",
  "log",
  "num_cpus",
@@ -6037,11 +5738,10 @@ dependencies = [
 
 [[package]]
 name = "sc-peerset"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfaa3d62db8ad549e6d21b6e353e00e2e7338c8623c01c79e8f36b035266a4b"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "libp2p",
  "log",
  "serde_json",
@@ -6051,9 +5751,8 @@ dependencies = [
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42c942480b516b4bd4a32d1434f634126220cb00c8d482658700cc58dc22c6f"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -6061,11 +5760,10 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc3793d8ff10dbeb0b683151a1ea33570dc994195cc29451e0b72ce35179adc"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -6094,12 +5792,11 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb4b79b9b6b410c745a00eb4ead11b2ef0819e6eac970a5ec6415abf82777be"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
- "futures 0.3.8",
+ "futures 0.3.5",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -6119,11 +5816,10 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9118867e60870b99cc1877edb4c35878babe6696335841e5b636dcba2fdb3d"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.29",
  "jsonrpc-core",
  "jsonrpc-http-server",
  "jsonrpc-ipc-server",
@@ -6139,15 +5835,15 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
  "directories",
  "exit-future",
  "extrinsic-info-runtime-api",
  "extrinsic-shuffler",
- "futures 0.1.30",
- "futures 0.3.8",
+ "futures 0.1.29",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "hash-db",
  "jsonrpc-core",
@@ -6157,7 +5853,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "pin-project",
  "rand 0.7.3",
  "random-seed-runtime-api",
  "sc-block-builder",
@@ -6203,9 +5899,8 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56341f78caf54af053889d1e863ca9b03004a3f471947805226fa8a6be9c9a59"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6218,16 +5913,15 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5883219d0ccec3e4d50079ba63f8accc71659b93537cff66de326a382b138c4b"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "pin-project",
  "rand 0.7.3",
  "serde",
  "slog",
@@ -6240,9 +5934,8 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "695f005588c8b6957e56c86bc4624969a0c1a8e4e4d2f4fe0bb4039a26a10503"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "erased-serde",
  "log",
@@ -6261,11 +5954,10 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f57f64ce160124404e4a140da79c7d363627830e5bb31b6ac54c6cd6955fdb"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
- "futures 0.3.8",
+ "futures 0.3.5",
  "linked-hash-map",
  "log",
  "parity-util-mem",
@@ -6283,11 +5975,10 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749ff49bf873dc43ed85ac86fce64d169c7c7397b720194799e7e6c6eb269972"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-diagnose",
  "intervalier",
  "log",
@@ -6324,14 +6015,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
- "curve25519-dalek 2.1.0",
- "getrandom 0.1.15",
+ "arrayvec 0.5.1",
+ "curve25519-dalek",
+ "getrandom",
  "merlin",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "sha2 0.8.2",
- "subtle 2.3.0",
+ "subtle 2.2.3",
  "zeroize",
 ]
 
@@ -6355,18 +6046,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
+checksum = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.10.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12bd20b94c7cdfda8c7ba9b92ad0d9a56e3fa018c25fca83b51aa664c9b4c0d"
+checksum = "e367622f934864ffa1c704ba2b82280aab856e3d8213c84c5720257eb34b15b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6431,19 +6122,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "serde"
-version = "1.0.117"
+name = "send_wrapper"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "a0eddf2e8f50ced781f288c19f18621fa72a3779e3cb58dbf23b07469b0abeb4"
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "serde"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6452,9 +6155,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "itoa",
  "ryu",
@@ -6474,19 +6177,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if 1.0.0",
- "cpuid-bool",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6500,12 +6190,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
+checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -6513,24 +6203,24 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "block-buffer 0.7.3",
+ "byte-tools",
+ "digest 0.8.1",
  "keccak",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.0"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
 dependencies = [
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -6541,18 +6231,19 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
+checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 dependencies = [
+ "arc-swap",
  "libc",
 ]
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "65211b7b6fc3f14ff9fc7a2011a434e3e6880585bd2e9e9396315ae24cbf7852"
 
 [[package]]
 name = "slab"
@@ -6615,15 +6306,36 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
+
+[[package]]
+name = "smol"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "620cbb3c6e34da57d3a248cda0cd01cd5848164dc062e764e65d06fe3ea7aed5"
+dependencies = [
+ "async-task",
+ "blocking",
+ "concurrent-queue",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "libc",
+ "once_cell 1.4.0",
+ "scoped-tls",
+ "slab",
+ "socket2",
+ "wepoll-sys-stjepang",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "snow"
-version = "0.7.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795dd7aeeee24468e5a32661f6d27f7b5cbed802031b2d7640c7b10f8fb2dd50"
+checksum = "32bf8474159a95551661246cda4976e89356999e3cbfef36f493dacc3fae1e8e"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -6632,18 +6344,18 @@ dependencies = [
  "rand_core 0.5.1",
  "ring",
  "rustc_version",
- "sha2 0.9.2",
- "subtle 2.3.0",
- "x25519-dalek 1.1.0",
+ "sha2 0.9.1",
+ "subtle 2.2.3",
+ "x25519-dalek",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.3.16"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
+checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -6651,25 +6363,24 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c71ed3d54db0a699f4948e1bb3e45b450fa31fe602621dee6680361d569c88"
+checksum = "85457366ae0c6ce56bf05a958aef14cd38513c236568618edbcd9a8c52cb80b0"
 dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
  "flate2",
- "futures 0.3.8",
+ "futures 0.3.5",
  "httparse",
  "log",
  "rand 0.7.3",
- "sha-1 0.9.2",
+ "sha-1",
 ]
 
 [[package]]
 name = "sp-allocator"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79a1db780708b6b71e9914e2b1d11b3e61c9bfb492c88b1024115e1a6661da"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
  "log",
@@ -6680,9 +6391,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953a3296335d9761311763dbe6855109ea4bea915e27cf5633d8b01057898302"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6696,9 +6406,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8247ca24a2a881af2ac675c8ec33584944965d6d45645bbec16fe327ce42dce6"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6709,9 +6418,8 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "885eca124aa6ce0bba57c08bc48c4357096996d630a77f572580ef8e2e4df034"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6723,8 +6431,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4d204b1cf8e1d4826804ffbd2edd2c4df385ee3046fa4581f09bc18977ea89"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6736,9 +6443,8 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7748c0e859bf4c3dda84849a72af83c9f85bb21a7b7c085ed161516fa00d1e"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6749,9 +6455,8 @@ dependencies = [
 
 [[package]]
 name = "sp-authorship"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58623adee1ed41752d76151762c80801758f88f85e4016d0338f2b01f4e7bd44"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6761,9 +6466,8 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d7fca8aa126a9d295843d592f44b48d8cf93880862baeff2968164598ab26c"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6774,9 +6478,8 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37387284973e2edceefaa673930282801ea238e5892a2cc6aa02f7f2e7601df"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
  "log",
@@ -6792,9 +6495,8 @@ dependencies = [
 
 [[package]]
 name = "sp-chain-spec"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150ce7661d02d4d0509a4a8364ab3b71a5ef2faf3f97d22d4b76bc0786d9e28b"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "serde",
  "serde_json",
@@ -6802,12 +6504,11 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b460103293bbf2f4193e43c4f031fdc099c5e27c782369bbb4dacc7765e84057"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-timer 3.0.2",
  "libp2p",
  "log",
@@ -6829,9 +6530,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8050a73302f354f45d0dee610e69ed39aadf43ab8a7528bdf3df8427276dc739"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -6849,9 +6549,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ea323ccf4ec8aad353fbc9016a1cb8cbf0d872d33bc8874cb0753b014fb7fc"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6859,9 +6558,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-vrf"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3345ee42ea5319bd6e3329bc3b5ee68b09f14d677378b27409a3a52d5ebe9990"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6872,17 +6570,16 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92ac5c674ee2cd9219d084301b4cbb82b28a94a0f3087bf4bea0ef3067ebb5c"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "base58",
  "blake2-rfc",
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "derive_more",
  "dyn-clonable",
  "ed25519-dalek",
- "futures 0.3.8",
+ "futures 0.3.5",
  "hash-db",
  "hash256-std-hasher",
  "hex",
@@ -6917,9 +6614,8 @@ dependencies = [
 
 [[package]]
 name = "sp-database"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1c352eceefe5bcdfc27f13a2fd038fc571b7aca5146f2cd651d40e9d2457dd"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6927,9 +6623,8 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3750b084e0f4677f6e834a974f30b1ba97fc2fe00185c9d03611a2228446dc"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6938,9 +6633,8 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d87fcd0e0fc5e025459cfe769803488d4894e36d0f8cef80b5239d2e7ef6580"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6950,9 +6644,8 @@ dependencies = [
 
 [[package]]
 name = "sp-finality-grandpa"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789d960506306f34fb0a2da547956ba1f23d6a29032291a7284c943906feddcb"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6967,9 +6660,8 @@ dependencies = [
 
 [[package]]
 name = "sp-finality-tracker"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5433473273a116241010551b9acfdbd7d33a9fdcda45c390eb707971568154"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6979,7 +6671,7 @@ dependencies = [
 [[package]]
 name = "sp-ignore-tx"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6990,9 +6682,8 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365e5aee23640631e63e8634f1d804e33c8fcb521f4052910f29abaa2df1c1cf"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -7003,11 +6694,10 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e1dee9244eb6cba1bef9b3a4ec288185e1380e455f1fd348b60252592c1cf0"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "hash-db",
  "libsecp256k1",
  "log",
@@ -7027,9 +6717,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f76feeb27b218d58523931ea2d708b622c3bd96a3be1c3a5895bba0f7a54c13"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7039,9 +6728,8 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54bb6d3d49dccf6ee26586a29ce8aabade8e102e51ed5009660ef7abb973eb7d"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7052,9 +6740,8 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections-compact"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d784c5576824b0ffa4cb359b7eebfd87511c49685b170b8214aabaa5f2454c87"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7064,9 +6751,8 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd5e101b2510ad84adaeb4589e6a94fdc741242ab1e39b89c87a647133205ad"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7075,9 +6761,8 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492126eb766b3b6740e4e4929d6527d37708598b7296a664f3680c0f0c1fc573"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "backtrace",
  "log",
@@ -7085,9 +6770,8 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c6678f4b42421e6dcdf3896a0c81a403c29ef1cf8d74b046d59125d40da911"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "serde",
  "sp-core",
@@ -7095,9 +6779,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62542f8ce9d5fcb43a4dd3c3a53326d33aacf9b0bc9d353d6fe9fd5ff3031747"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7118,9 +6801,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7e363c480cc8c9019b84f85d10c0b56a184079d5d840d2d1d55087ad835dc6"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7135,9 +6817,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf56a38544293e54dbe0aa7b6aed1e046bfc704b6fc3de7255897dca98ccb1"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7148,9 +6829,8 @@ dependencies = [
 
 [[package]]
 name = "sp-serializer"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643933e971979094c9d4b27b015c7250985a262e405bb9ad090336d8ceb5b2b9"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "serde",
  "serde_json",
@@ -7158,9 +6838,8 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d138b1f548933003feaa967de49ed87066643073bcc41be45ef2daaa0991c133"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7172,9 +6851,8 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b06f9839d8b4312486626bde31d6cd7763dd9b7d93ea9e70c01ca30f0998032"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7183,9 +6861,8 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58335de98bca196683a8ef22195a8a43b457b8bc705dba3124138ffc2ee720"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "hash-db",
  "log",
@@ -7193,7 +6870,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
@@ -7205,15 +6882,13 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2d6e166cead2d3b1d3d8fe0e787d076b7d0296b1760a0d7d340846d0ba42c5"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 
 [[package]]
 name = "sp-storage"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4625e6f8f40995939560f48f89028f658b7929657c68d01c571c81ab5619ff"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7225,9 +6900,8 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb398f0a5d2798ad4e02450b3089534547b448d22ebe6f3b2c03f74170f58d1"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7240,9 +6914,8 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a5c42c5450991ca3a28c190e75122f5ccedbcb024953e7c357e7aa2afd8534"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7254,12 +6927,11 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b34ee48341c17c6e2f1e55f6076918f46b0c4505a99ad69ab1edda8b45bbd8"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "derive_more",
- "futures 0.3.8",
+ "futures 0.3.5",
  "log",
  "parity-scale-codec",
  "serde",
@@ -7270,9 +6942,8 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3aae57c8ae81ba978503137a8c625d2963eb425dd90dec0d96b4ed18d8bfd55"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7285,11 +6956,10 @@ dependencies = [
 
 [[package]]
 name = "sp-utils"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84310a02e2ac89b5e288d7af980414fd88753e3caba92aab1983cd2819991150"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "futures-core",
  "futures-timer 3.0.2",
  "lazy_static",
@@ -7298,9 +6968,8 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21935199c8765f0d02facc718f9c83149a70ea684fb03612e5161c682b38a301"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7311,9 +6980,8 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c28225e8b7ec7e260f8b46443f8731abda206334cb75c740d2407693f38167"
+version = "2.0.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7350,12 +7018,20 @@ dependencies = [
 
 [[package]]
 name = "stream-cipher"
-version = "0.7.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80e15f898d8d8f25db24c253ea615cc14acf418ff307822995814e7d42cfa89"
+checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
 dependencies = [
- "block-cipher",
- "generic-array 0.14.4",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "stream-cipher"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f8ed9974042b8c3672ff3030a69fcc03b74c47c3d1ecb7755e8a3626011e88"
+dependencies = [
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -7375,9 +7051,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -7386,9 +7062,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -7433,9 +7109,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-build-script-utils"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14feab86fe31e7d0a485d53d7c1c634c426f7ae5b8ce4f705b2e49a35713fcb"
+checksum = "9726c2926418239f73d4d939fcc4ceb5c6697609426c64dd3bcf664f06986afa"
 dependencies = [
  "platforms",
 ]
@@ -7445,7 +7121,7 @@ name = "substrate-frame-rpc-system"
 version = "2.0.0"
 dependencies = [
  "frame-system-rpc-runtime-api",
- "futures 0.3.8",
+ "futures 0.3.5",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -7466,14 +7142,13 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3e361741d066bfc29554b9f1bc8e4ac927eb4bd33dd8bb0486969edd8b0b5a"
+version = "0.8.1"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "async-std",
  "derive_more",
  "futures-util",
- "hyper 0.13.9",
+ "hyper 0.13.7",
  "log",
  "prometheus",
  "tokio 0.2.22",
@@ -7482,10 +7157,9 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974d8429436089109975f180a3969d7f905ce6db4d325e427b1339eed67bcfe6"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "substrate-test-utils-derive",
  "tokio 0.2.22",
 ]
@@ -7493,8 +7167,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c7fb300e48fa297cc02b0b5b6fea2ddaeafb05d7e0be76b6872ea3d8adf117"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6548c16362502a57ca4fe568e83dab6e2cf38a7b"
 dependencies = [
  "proc-macro-crate",
  "quote",
@@ -7515,19 +7188,30 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
-version = "2.3.0"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7560,7 +7244,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "rand 0.7.3",
  "redox_syscall",
@@ -7588,18 +7272,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7626,12 +7310,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -7643,7 +7326,7 @@ checksum = "b0165e045cc2ae1660270ca65e1676dbaab60feb0f91b10f7d0665e9b47e31f2"
 dependencies = [
  "failure",
  "hmac",
- "once_cell 1.5.1",
+ "once_cell 1.4.0",
  "pbkdf2",
  "rand 0.7.3",
  "rustc-hash",
@@ -7671,9 +7354,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 
 [[package]]
 name = "tokio"
@@ -7682,7 +7365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "mio",
  "num_cpus",
  "tokio-codec",
@@ -7730,7 +7413,7 @@ checksum = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 dependencies = [
  "bytes 0.4.12",
  "either",
- "futures 0.1.30",
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -7740,7 +7423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "tokio-io",
 ]
 
@@ -7750,7 +7433,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.29",
  "tokio-executor 0.1.10",
 ]
 
@@ -7760,8 +7443,8 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.30",
+ "crossbeam-utils",
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -7781,7 +7464,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.29",
  "tokio-io",
  "tokio-threadpool",
 ]
@@ -7793,15 +7476,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "log",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7815,7 +7498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d282d483052288b2308ba5ee795f5673b159c9bdf63c385a05609da782a5eae"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "mio",
  "mio-named-pipes",
  "tokio 0.1.22",
@@ -7827,8 +7510,8 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.30",
+ "crossbeam-utils",
+ "futures 0.1.29",
  "lazy_static",
  "log",
  "mio",
@@ -7842,9 +7525,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.14.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
+checksum = "228139ddd4fea3fa345a29233009635235833e52807af7ea6448ead03890d6a9"
 dependencies = [
  "futures-core",
  "rustls",
@@ -7858,7 +7541,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -7868,7 +7551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
 dependencies = [
  "fnv",
- "futures 0.1.30",
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -7889,7 +7572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "iovec",
  "mio",
  "tokio-io",
@@ -7902,10 +7585,10 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 dependencies = [
- "crossbeam-deque 0.7.3",
+ "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils 0.7.2",
- "futures 0.1.30",
+ "crossbeam-utils",
+ "futures 0.1.29",
  "lazy_static",
  "log",
  "num_cpus",
@@ -7919,8 +7602,8 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
- "crossbeam-utils 0.7.2",
- "futures 0.1.30",
+ "crossbeam-utils",
+ "futures 0.1.29",
  "slab",
  "tokio-executor 0.1.10",
 ]
@@ -7932,7 +7615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "log",
  "mio",
  "tokio-codec",
@@ -7947,7 +7630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.30",
+ "futures 0.1.29",
  "iovec",
  "libc",
  "log",
@@ -7974,9 +7657,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
 ]
@@ -7989,13 +7672,12 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "log",
- "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -8013,21 +7695,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
-dependencies = [
- "pin-project 0.4.27",
- "tracing",
 ]
 
 [[package]]
@@ -8043,9 +7715,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
 dependencies = [
  "serde",
  "tracing-core",
@@ -8053,9 +7725,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "f7b33f8b2ef2ab0c3778c12646d9c42a24f7772bee4cdafc72199644a9f58fdc"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -8065,9 +7737,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.4.2",
- "thread_local",
- "tracing",
+ "smallvec 1.4.1",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -8075,15 +7745,15 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.22.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e55f7ace33d6237e14137e386f4e1672e2a5c6bbc97fef9f438581a143971f0"
+checksum = "39f1a9a9252d38c5337cf0c5392988821a5cf1b2103245016968f2ab41de9e38"
 dependencies = [
  "hash-db",
- "hashbrown 0.8.2",
+ "hashbrown 0.8.1",
  "log",
  "rustc-hex",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
@@ -8103,13 +7773,11 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "twox-hash"
-version = "1.6.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
+checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "cfg-if 0.1.10",
  "rand 0.7.3",
- "static_assertions",
 ]
 
 [[package]]
@@ -8120,11 +7788,11 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.8.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
+checksum = "173cd16430c206dc1a430af8a89a0e9c076cf15cb42b4aedb10e8cc8fee73681"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder 1.4.3",
  "crunchy",
  "rustc-hex",
  "static_assertions",
@@ -8181,9 +7849,15 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
- "generic-array 0.14.4",
- "subtle 2.3.0",
+ "generic-array 0.14.3",
+ "subtle 2.2.3",
 ]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67332660eb59a6f1eb24ff1220c9e8d01738a8503c6002e30bcfe4bd9f2b4a9"
 
 [[package]]
 name = "unsigned-varint"
@@ -8226,11 +7900,10 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 dependencies = [
- "form_urlencoded",
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
@@ -8241,12 +7914,6 @@ name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
-
-[[package]]
-name = "vec-arena"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
 
 [[package]]
 name = "vec_map"
@@ -8268,9 +7935,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "waker-fn"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+checksum = "9571542c2ce85ce642e6b58b3364da2fb53526360dfb7c211add4f5c23105ff7"
 
 [[package]]
 name = "want"
@@ -8278,7 +7945,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.29",
  "log",
  "try-lock",
 ]
@@ -8300,26 +7967,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -8332,11 +7993,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.18"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -8344,9 +8005,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8354,9 +8015,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8367,20 +8028,21 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
 
 [[package]]
 name = "wasm-timer"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+checksum = "324c5e65a08699c9c4334ba136597ab22b85dccd4b65dd1e36ccf8f723a95b54"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "js-sys",
- "parking_lot 0.11.0",
+ "parking_lot 0.9.0",
  "pin-utils",
+ "send_wrapper 0.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -8429,13 +8091,13 @@ checksum = "1cd3c4f449382779ef6e0a7c3ec6752ae614e20a42e4100000c3efdc973100e2"
 dependencies = [
  "anyhow",
  "backtrace",
- "cfg-if 0.1.10",
+ "cfg-if",
  "lazy_static",
  "libc",
  "log",
  "region",
  "rustc-demangle",
- "smallvec 1.4.2",
+ "smallvec 1.4.1",
  "target-lexicon",
  "wasmparser 0.59.0",
  "wasmtime-environ",
@@ -8471,7 +8133,7 @@ dependencies = [
  "anyhow",
  "base64 0.12.3",
  "bincode",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
@@ -8500,7 +8162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e914c013c7a9f15f4e429d5431f2830fb8adb56e40567661b69c5ec1d645be23"
 dependencies = [
  "anyhow",
- "cfg-if 0.1.10",
+ "cfg-if",
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
@@ -8543,7 +8205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8d4d1af8dd5f7096cfcc89dd668d358e52980c38cce199643372ffd6590e27"
 dependencies = [
  "anyhow",
- "cfg-if 0.1.10",
+ "cfg-if",
  "gimli 0.21.0",
  "lazy_static",
  "libc",
@@ -8563,7 +8225,7 @@ checksum = "3a25f140bbbaadb07c531cba99ce1a966dba216138dc1b2a0ddecec851a01a93"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if",
  "indexmap",
  "lazy_static",
  "libc",
@@ -8578,27 +8240,27 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "27.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c3ef5f6a72dffa44c24d5811123f704e18a1dbc83637d347b1852b41d3835c"
+checksum = "0b1844f66a2bc8526d71690104c0e78a8e59ffa1597b7245769d174ebb91deb5"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.28"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835cf59c907f67e2bbc20f50157e08f35006fe2a8444d8ec9f5683e22f937045"
+checksum = "ce85d72b74242c340e9e3492cfb602652d7bb324c3172dd441b5577e39a2e18c"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8633,10 +8295,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-sys"
-version = "3.0.1"
+name = "wepoll-sys-stjepang"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+checksum = "6fd319e971980166b53e17b1026812ad66c6b54063be879eb182342b55284694"
 dependencies = [
  "cc",
 ]
@@ -8709,18 +8371,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 dependencies = [
- "curve25519-dalek 2.1.0",
- "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "x25519-dalek"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
-dependencies = [
- "curve25519-dalek 3.0.0",
+ "curve25519-dalek",
  "rand_core 0.5.1",
  "zeroize",
 ]
@@ -8763,7 +8414,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aeb8c4043cac71c3c299dff107171c220d179492350ea198e109a414981b83c"
 dependencies = [
- "futures 0.3.8",
+ "futures 0.3.5",
  "log",
  "nohash-hasher",
  "parking_lot 0.11.0",
@@ -8773,18 +8424,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8822,8 +8473,3 @@ dependencies = [
  "itertools 0.9.0",
  "libc",
 ]
-
-[[patch.unused]]
-name = "pallet-authorship"
-version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#c94327a21d3fd4a14d4ba4f1709150bcb5ea0db4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,23 +7,3 @@ members = [
     'pallets/xyk',
     'runtime',
 ]
-
-[patch.crates-io]
-artemis-asset = { git = 'https://github.com/mangata-finance/snowbridge', branch="mangata-dev" }
-artemis-core = { git = 'https://github.com/mangata-finance/snowbridge', branch="mangata-dev" }
-artemis-erc20-app = { git = 'https://github.com/mangata-finance/snowbridge', branch="mangata-dev" }
-artemis-eth-app = { git = 'https://github.com/mangata-finance/snowbridge', branch="mangata-dev" }
-extrinsic-info-runtime-api = { git = 'https://github.com/mangata-finance/substrate', branch='mangata-dev'}
-frame-executive = { git = 'https://github.com/mangata-finance/substrate', branch='mangata-dev'}
-orml-tokens = { git = 'https://github.com/mangata-finance/open-runtime-module-library', branch="mangata-dev" }
-pallet-authorship = { git = 'https://github.com/mangata-finance/substrate', branch='mangata-dev'}
-pallet-random-seed = { git = 'https://github.com/mangata-finance/substrate', branch='mangata-dev'}
-pallet-staking = { path="pallets/staking"}
-pallet-timestamp = { git = 'https://github.com/mangata-finance/substrate', branch='mangata-dev'}
-pallet-treasury = { git = 'https://github.com/mangata-finance/substrate', branch='mangata-dev'}
-pallet-verifier = { git = 'https://github.com/mangata-finance/snowbridge', branch="mangata-dev" }
-random-seed-runtime-api = { git = 'https://github.com/mangata-finance/substrate', branch='mangata-dev'}
-sc-basic-authorship = { git = 'https://github.com/mangata-finance/substrate', branch='mangata-dev' }
-sc-block-builder = { git = 'https://github.com/mangata-finance/substrate', branch='mangata-dev' }
-sc-consensus-babe = { git = 'https://github.com/mangata-finance/substrate', branch='mangata-dev' }
-sc-service = { git = 'https://github.com/mangata-finance/substrate', branch='mangata-dev' }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,6 +20,8 @@ substrate-build-script-utils = '2.0.0'
 [dependencies.artemis-core]
 default-features = false
 version = "0.1.1"
+git = "https://github.com/mangata-finance/snowbridge"
+branch = "mangata-dev" 
 
 [dependencies]
 jsonrpc-core = "15.0"
@@ -31,56 +33,57 @@ structopt = '0.3.8'
 mangata-runtime = { path = '../runtime', version = '2.0.0' }
 
 # Substrate dependencies
-frame-benchmarking = '2.0.0'
-frame-benchmarking-cli = '2.0.0'
-pallet-transaction-payment-rpc = '2.0.0'
-pallet-transaction-payment = '2.0.0'
-sc-basic-authorship = { version = '0.8.0'}
-sc-cli = { features = ['wasmtime'], version = '0.8.0' }
-sc-client-api = '2.0.0'
-sc-consensus = '0.8.0'
-sc-consensus-babe = { version = '0.8.0'}
-sp-consensus-babe = '0.8.0'
-sp-authority-discovery = '2.0.0'
+frame-benchmarking = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-benchmarking-cli = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-transaction-payment-rpc = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-transaction-payment = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-basic-authorship = { version = '0.8.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-cli = { features = ['wasmtime'], version = '0.8.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-client-api = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-consensus = { version = '0.8.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-consensus-babe = { version = '0.8.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-consensus-babe = { version = '0.8.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-authority-discovery = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 #grandpa-primitives = {package = 'sp-finality-grandpa', version = '2.0.0'}
-sp-timestamp = '2.0.0'
-sp-finality-tracker = '2.0.0'
-sp-keyring  = '2.0.0'
-sp-io  = '2.0.0'
-sc-chain-spec  = '2.0.0'
-sc-network  = '0.8.0'
+sp-timestamp = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-finality-tracker = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-keyring  = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-io  = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-chain-spec  = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-network  = { version = '0.8.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 #grandpa  = {package = 'sc-finality-grandpa', version = '0.8.0'}
-sc-client-db  = '0.8.0'
-sc-offchain  = '2.0.0'
-sc-tracing  = '2.0.0'
-sc-telemetry  = '2.0.0'
-sc-authority-discovery  = '0.8.0'
-frame-system  = '2.0.0'
-pallet-balances = '2.0.0'
-frame-support = '2.0.0'
-pallet-authority-discovery = '2.0.0'
-pallet-staking = {version='2.0.0', path="../pallets/staking"}
-pallet-grandpa = '2.0.0'
+sc-client-db  = { version = '0.8.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-offchain  = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-tracing  = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-telemetry  = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-authority-discovery  = { version = '0.8.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-system  = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-balances = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-support = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-authority-discovery = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-grandpa = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 
-sc-executor = { features = ['wasmtime'], version = '0.8.0' }
-sc-finality-grandpa = '0.8.0'
-sc-rpc = '2.0.0'
-sc-rpc-api = '0.8.0'
-sc-service = { features = ['wasmtime'], version = '0.8.0' }
-sc-transaction-pool = {version = '2.0.0'}
-sp-api = '2.0.0'
-sp-block-builder = '2.0.0'
-sp-blockchain = '2.0.0'
-sp-consensus = '0.8.0'
-sp-core = '2.0.0'
-sp-finality-grandpa = '2.0.0'
-sp-inherents = '2.0.0'
-sp-runtime = '2.0.0'
-sp-transaction-pool = '2.0.0'
+pallet-staking = {version='2.0.0', path="../pallets/staking"}
+
+sc-executor = { features = ['wasmtime'], version = '0.8.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-finality-grandpa = { version = '0.8.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-rpc = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-rpc-api = { version = '0.8.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-service = { features = ['wasmtime'], version = '0.8.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-transaction-pool = {version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-api = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-block-builder = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-blockchain = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-consensus = { version = '0.8.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-core = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-finality-grandpa = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-inherents = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-runtime = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-transaction-pool = { version = '2.0.0', git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 substrate-frame-rpc-system = { version = '2.0.0', path = '../utils/frame/rpc/system'}
 xyk-rpc = { default-features = false, version = '2.0.0', path = '../pallets/xyk/rpc' }
 xyk-runtime-api = { default-features = false, version = '2.0.0', path = '../pallets/xyk/runtime-api' }
-extrinsic-info-runtime-api = {  default-features = false, version = '2.0.0' }
+extrinsic-info-runtime-api = {  default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 
 hex-literal = { version = "0.3.1", default-features = false }
 

--- a/pallets/assets-info/Cargo.toml
+++ b/pallets/assets-info/Cargo.toml
@@ -19,16 +19,16 @@ package = 'parity-scale-codec'
 version = '1.3.4'
 
 [dependencies]
-frame-support = { default-features = false, version = '2.0.0' }
-frame-system = { default-features = false, version = '2.0.0' }
-orml-tokens = { default-features = false, version="0.3.1" }
 serde = { version = "1.0.101", optional = true }
-mangata-primitives = { path = '../../primitives/mangata', default-features = false, version = '0.1.0' }
+frame-support = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-system = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+orml-tokens = { default-features = false, version="0.3.1" , git = "https://github.com/mangata-finance/open-runtime-module-library", branch = "mangata-dev" }
+mangata-primitives = { default-features = false, version = '0.1.0' , path = '../../primitives/mangata'}
 
 [dev-dependencies]
-sp-core = { default-features = false, version = '2.0.0' }
-sp-io = { default-features = false, version = '2.0.0' }
-sp-runtime = { default-features = false, version = '2.0.0' }
+sp-core = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-io = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-runtime = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 
 [features]
 default = ['std']

--- a/pallets/bridge/Cargo.toml
+++ b/pallets/bridge/Cargo.toml
@@ -24,42 +24,60 @@ version = "1.3.4"
 [dependencies.frame-support]
 default-features = false
 version = "2.0.0"
+git = "https://github.com/mangata-finance/substrate"
+branch = "mangata-dev" 
 
 [dependencies.frame-system]
 default-features = false
 version = "2.0.0"
+git = "https://github.com/mangata-finance/substrate"
+branch = "mangata-dev" 
 
 [dependencies.sp-core]
 default-features = false
 version = "2.0.0"
+git = "https://github.com/mangata-finance/substrate"
+branch = "mangata-dev" 
 
 [dependencies.sp-std]
 default-features = false
 version = "2.0.0"
+git = "https://github.com/mangata-finance/substrate"
+branch = "mangata-dev" 
 
 [dependencies.sp-io]
 default-features = false
 version = "2.0.0"
+git = "https://github.com/mangata-finance/substrate"
+branch = "mangata-dev" 
 
 [dependencies.sp-runtime]
 default-features = false
 version = "2.0.0"
+git = "https://github.com/mangata-finance/substrate"
+branch = "mangata-dev" 
 
 [dependencies.artemis-core]
 default-features = false
 version = "0.1.1"
+git = "https://github.com/mangata-finance/snowbridge"
+branch = "mangata-dev" 
+
+
+ 
 
 
 [dependencies]
 hex-literal = { version = "0.3.1", default-features = true }
-frame-benchmarking = { version = "2.0.0", default-features = false, optional = true }
+frame-benchmarking = { version = "2.0.0", default-features = false, optional = true , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 
 [dev-dependencies]
-pallet-verifier = "0.1.1"
-artemis-erc20-app = "0.1.1"
-artemis-eth-app = "0.1.1"
-artemis-asset = "0.1.1"
-orml-tokens = "0.3.1"
+pallet-verifier = {version = "0.1.1", git = "https://github.com/mangata-finance/snowbridge", branch = "mangata-dev"}
+artemis-erc20-app = {version = "0.1.1", git = "https://github.com/mangata-finance/snowbridge", branch = "mangata-dev"}
+artemis-eth-app = {version = "0.1.1", git = "https://github.com/mangata-finance/snowbridge", branch = "mangata-dev"}
+artemis-asset = {version = "0.1.1", git = "https://github.com/mangata-finance/snowbridge", branch = "mangata-dev"}
+orml-tokens = {version = "0.3.1", git = "https://github.com/mangata-finance/open-runtime-module-library", branch = "mangata-dev"}
+
 
 mangata-primitives = { path = '../../primitives/mangata', default-features = false, version = '0.1.0' }
 

--- a/pallets/staking/Cargo.toml
+++ b/pallets/staking/Cargo.toml
@@ -16,33 +16,33 @@ targets = ["x86_64-unknown-linux-gnu"]
 static_assertions = "1.1.0"
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0", default-features = false }
-sp-npos-elections = { version = "2.0.0", default-features = false }
-sp-io ={ version = "2.0.0", default-features = false }
-sp-runtime = { version = "2.0.0", default-features = false }
-sp-staking = { version = "2.0.0", default-features = false }
-frame-support = { version = "2.0.0", default-features = false }
-frame-system = { version = "2.0.0", default-features = false }
-pallet-session = { version = "2.0.0", default-features = false, features = ["historical"] }
-pallet-authorship = { version = "2.0.0", default-features = false }
-sp-application-crypto = { version = "2.0.0", default-features = false }
+sp-std = { version = "2.0.0", default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-npos-elections = { version = "2.0.0", default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-io ={ version = "2.0.0", default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-runtime = { version = "2.0.0", default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-staking = { version = "2.0.0", default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-support = { version = "2.0.0", default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-system = { version = "2.0.0", default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-session = { version = "2.0.0", default-features = false, features = ["historical"] , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-authorship = { version = "2.0.0", default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-application-crypto = { version = "2.0.0", default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 pallet-xyk = { version = "0.1.0", default-features = false, path = "../xyk" }
-orml-tokens = { version = "0.3.1", default-features=false}
+orml-tokens = { version = "0.3.1", default-features=false, git = "https://github.com/mangata-finance/open-runtime-module-library", branch = "mangata-dev" }
 mangata-primitives = { path = '../../primitives/mangata', default-features = false, version = '0.1.0' }
-sp-core = { version = "2.0.0", default-features = false }
+sp-core = { version = "2.0.0", default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 
 # Optional imports for benchmarking
-frame-benchmarking = { version = "2.0.0", default-features = false, optional = true }
+frame-benchmarking = { version = "2.0.0", default-features = false, optional = true , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 rand_chacha = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
-sp-storage = { version = "2.0.0" }
-sp-tracing = { version = "2.0.0" }
-pallet-balances = { version = "2.0.0" }
-pallet-timestamp = { version = "2.0.0"}
+sp-storage = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-tracing = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-balances = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-timestamp = { version = "2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 pallet-staking-reward-curve = { version = "2.0.0",  path = "../staking/reward-curve" }
-substrate-test-utils = { version = "2.0.0" }
-frame-benchmarking = { version = "2.0.0"}
+substrate-test-utils = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-benchmarking = { version = "2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 rand_chacha = { version = "0.2" }
 parking_lot = "0.10.2"
 hex = "0.4"

--- a/pallets/staking/fuzzer/Cargo.toml
+++ b/pallets/staking/fuzzer/Cargo.toml
@@ -17,17 +17,17 @@ honggfuzz = "0.5"
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
 pallet-staking = { version = "2.0.0", features = ["runtime-benchmarks"], path = ".." }
 pallet-staking-reward-curve = { version = "2.0.0",  path = "../reward-curve" }
-pallet-session = { version = "2.0.0" }
-pallet-indices = { version = "2.0.0" }
-pallet-balances = { version = "2.0.0" }
-pallet-timestamp = { version = "2.0.0" }
-frame-system = { version = "2.0.0" }
-frame-support = { version = "2.0.0" }
-sp-std = { version = "2.0.0" }
-sp-io ={ version = "2.0.0" }
-sp-core = { version = "2.0.0" }
-sp-npos-elections = { version = "2.0.0" }
-sp-runtime = { version = "2.0.0" }
+pallet-session = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }
+pallet-indices = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }
+pallet-balances = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }
+pallet-timestamp = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }
+frame-system = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }
+frame-support = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }
+sp-std = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }
+sp-io ={ version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }
+sp-core = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }
+sp-npos-elections = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }
+sp-runtime = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }
 
 [[bin]]
 name = "submit_solution"

--- a/pallets/staking/reward-curve/Cargo.toml
+++ b/pallets/staking/reward-curve/Cargo.toml
@@ -21,4 +21,4 @@ proc-macro2 = "1.0.6"
 proc-macro-crate = "0.1.4"
 
 [dev-dependencies]
-sp-runtime = { version = "2.0.0" }
+sp-runtime = { version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"  }

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -18,21 +18,24 @@ version = '1.3.4'
 hex = { package = "rustc-hex", version = "2.1.0", default-features = false }
 hex-literal = { version = "0.3.1", default-features = false }
 serde = { version = "1.0.111", optional = true }
-frame-support = { default-features = false, version = '2.0.0' }
-frame-system = { default-features = false, version = '2.0.0' }
-orml-tokens = {  default-features = false, version = '0.3.1' }
-sp-runtime = { default-features = false, version = '2.0.0' }
-sp-core = { default-features = false, version = '2.0.0' }
-sp-std = { version = "2.0.0", default-features = false }
-mangata-primitives = { path = '../../primitives/mangata', default-features = false, version = '0.1.0' }
-sp-arithmetic = { default-features = false, version = '2.0.0' }
+
+frame-support = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-system = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-runtime = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-core = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-std = { version = "2.0.0", default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+mangata-primitives = { default-features = false, version = '0.1.0' , path = '../../primitives/mangata'}
+sp-arithmetic = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+
+orml-tokens = {  default-features = false, version = '0.3.1' , git = "https://github.com/mangata-finance/open-runtime-module-library", branch = "mangata-dev" }
+
 pallet-assets-info = { path = '../assets-info', default-features = false, version = '2.0.0' }
 
 
 
 [dev-dependencies]
 
-sp-io = { default-features = false, version = '2.0.0' }
+sp-io = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 
 [features]
 default = ['std']

--- a/pallets/xyk/rpc/Cargo.toml
+++ b/pallets/xyk/rpc/Cargo.toml
@@ -15,12 +15,12 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 
 # Substrate packages
 
-sp-api = { version = '2.0.0', default-features = false }
-sp-blockchain = { version = '2.0.0', default-features = false}
-sp-rpc = { version = '2.0.0', default-features = false}
-sp-core = { version = '2.0.0', default-features = false}
-sp-std = { version = '2.0.0', default-features = false}
-sp-runtime = { version = '2.0.0', default-features = false}
+sp-api = { version = '2.0.0', default-features = false , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-blockchain = { version = '2.0.0', default-features = false, git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-rpc = { version = '2.0.0', default-features = false, git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-core = { version = '2.0.0', default-features = false, git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-std = { version = '2.0.0', default-features = false, git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-runtime = { version = '2.0.0', default-features = false, git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 
 # local packages
 

--- a/pallets/xyk/runtime-api/Cargo.toml
+++ b/pallets/xyk/runtime-api/Cargo.toml
@@ -7,11 +7,11 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-api = { version = '2.0.0', default-features = false}
-sp-runtime = { default-features = false, version = '2.0.0' }
-frame-support = { default-features = false, version = '2.0.0' }
-frame-system = { default-features = false, version = '2.0.0' }
-sp-core = { default-features = false, version = '2.0.0' }
+sp-api = { version = '2.0.0', default-features = false, git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-runtime = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-support = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-system = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-core = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,49 +26,49 @@ serde = { features = ['derive'], optional = true, version = '1.0.101' }
 # local dependencies
 pallet-xyk = { path = '../pallets/xyk', default-features = false, version = '0.1.0' }
 xyk-runtime-api = { path = '../pallets/xyk/runtime-api', default-features = false, version = '2.0.0' }
-random-seed-runtime-api = {  default-features = false, version = '2.0.0' }
-extrinsic-info-runtime-api = {  default-features = false, version = '2.0.0' }
-frame-executive = { default-features = false, version = '2.0.0' }
-pallet-timestamp = { default-features = false, version = '2.0.0' }
-pallet-random-seed = {  default-features = false, version='2.0.0' }
+random-seed-runtime-api = {  default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+extrinsic-info-runtime-api = {  default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-executive = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-timestamp = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-random-seed = {  default-features = false, version='2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 pallet-assets-info = { path = '../pallets/assets-info', default-features = false, version = '2.0.0' }
 pallet-staking = { path = '../pallets/staking', default-features = false, version = "2.0.0" }
 pallet-staking-reward-curve = { path = '../pallets/staking/reward-curve', default-features = false, version = "2.0.0" }
-pallet-treasury = { default-features = false, version='2.0.0' }
+pallet-treasury = { default-features = false, version='2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 mangata-primitives = { path = '../primitives/mangata', default-features = false, version = "0.1.0" }
-orml-tokens = {  default-features = false, branch="mangata-dev" }
+orml-tokens = {  default-features = false, version = "0.3.1", git = "https://github.com/mangata-finance/open-runtime-module-library", branch = "mangata-dev" }
 
 # Substrate dependencies
-frame-benchmarking = { default-features = false, optional = true, version = '2.0.0' }
-frame-support = { default-features = false, version = '2.0.0' }
-frame-system = { default-features = false, version = '2.0.0' }
-frame-system-benchmarking = { default-features = false, optional = true, version = '2.0.0' }
-frame-system-rpc-runtime-api = { default-features = false, version = '2.0.0' }
-pallet-babe = { default-features = false, version = "2.0.0" }
-pallet-offences = { default-features = false, version = "2.0.0" }
-pallet-session = { default-features = false, version = "2.0.0" }
-pallet-authorship = { default-features = false, version = "2.0.0" }
-pallet-balances = { default-features = false, version = '2.0.0' }
-pallet-grandpa = { default-features = false, version = '2.0.0' }
-pallet-randomness-collective-flip = { default-features = false, version = '2.0.0' }
-pallet-sudo = { default-features = false, version = '2.0.0' }
-pallet-transaction-payment = { default-features = false, version = '2.0.0' }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = '2.0.0' }
-sp-api = { default-features = false, version = '2.0.0' }
-sp-block-builder = { default-features = false, version = '2.0.0' }
-sp-consensus-babe = { default-features = false, version = "0.8.0" }
-sp-core = { default-features = false, version = '2.0.0' }
-sp-inherents = { default-features = false, version = '2.0.0' }
-sp-offchain = { default-features = false, version = '2.0.0' }
-sp-runtime = { default-features = false, version = '2.0.0' }
-sp-session = { default-features = false, version = '2.0.0' }
-sp-std = { default-features = false, version = '2.0.0' }
-sp-transaction-pool = { default-features = false, version = '2.0.0' }
-sp-version = { default-features = false, version = '2.0.0' }
-verifier = { default-features = false, package = "pallet-verifier", version = "0.1.1" }
-bridged-asset = { default-features = false, package = "artemis-asset", version = "0.1.1" }
-eth-app = { default-features = false, package = "artemis-eth-app", version = "0.1.1" }
-erc20-app = { default-features = false, package = "artemis-erc20-app", version = "0.1.1" }
+frame-benchmarking = { default-features = false, optional = true, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-support = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-system = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-system-benchmarking = { default-features = false, optional = true, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-system-rpc-runtime-api = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-babe = { default-features = false, version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-offences = { default-features = false, version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-session = { default-features = false, version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-authorship = { default-features = false, version = "2.0.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-balances = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-grandpa = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-randomness-collective-flip = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-sudo = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-transaction-payment = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-api = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-block-builder = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-consensus-babe = { default-features = false, version = "0.8.0" , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-core = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-inherents = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-offchain = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-runtime = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-session = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-std = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-transaction-pool = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-version = { default-features = false, version = '2.0.0' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+verifier = { default-features = false, package = "pallet-verifier", version = "0.1.1" , git = "https://github.com/mangata-finance/snowbridge", branch = "mangata-dev"}
+bridged-asset = { default-features = false, package = "artemis-asset", version = "0.1.1" , git = "https://github.com/mangata-finance/snowbridge", branch = "mangata-dev"}
+eth-app = { default-features = false, package = "artemis-eth-app", version = "0.1.1" , git = "https://github.com/mangata-finance/snowbridge", branch = "mangata-dev"}
+erc20-app = { default-features = false, package = "artemis-erc20-app", version = "0.1.1" , git = "https://github.com/mangata-finance/snowbridge", branch = "mangata-dev"}
 
 # Snowmangata-dev pallets
 

--- a/scripts/dev_manifest.sh
+++ b/scripts/dev_manifest.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+REPO_ROOT=$(readlink -f $(dirname $(readlink -f $0))/..)
+MANIFEST_PATH=$REPO_ROOT/Cargo.toml
+LOCAL_SUBSTRATE_REPO_PATH=$1
+
+if [ -z "$LOCAL_SUBSTRATE_REPO_PATH" ]; then
+    echo "usage $0 PATH_TO_SUBSTRATE_REPO"
+    exit -1
+fi
+
+# remove local changes to the file
+git -C $REPO_ROOT checkout Cargo.toml > /dev/null
+echo '[patch."https://github.com/mangata-finance/substrate"]' >> $MANIFEST_PATH
+
+# recursively find all packages from local repository and patch them temporarly
+for i in `find $LOCAL_SUBSTRATE_REPO_PATH -name Cargo.toml`; do
+    MANIFEST_ABS_PATH=$(readlink -f $i)
+    git -C $LOCAL_SUBSTRATE_REPO_PATH ls-files --error-unmatch $MANIFEST_ABS_PATH &> /dev/null
+    if [ 0 -eq $? ] ; then
+        PACKAGE_PATH=`dirname $i`
+        PACKAGE_NAME=`sed -n 's/.*name.*=.*\"\(.*\)\"/\1/p' $i | head -1`
+        if [ -n "$PACKAGE_NAME" ]; then 
+            echo "$PACKAGE_NAME = { path = \"$PACKAGE_PATH\" }" >> $MANIFEST_PATH
+        fi
+    fi
+done

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-client-api = "2.0.0"
+sc-client-api = {version="2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev"}
 codec = { package = "parity-scale-codec", version = "1.3.1" }
 futures = { version = "0.3.4", features = ["compat"] }
 jsonrpc-core = "15.0.0"
@@ -21,16 +21,16 @@ jsonrpc-core-client = "15.0.0"
 jsonrpc-derive = "15.0.0"
 log = "0.4.8"
 serde = { version = "1.0.101", features = ["derive"] }
-sp-runtime = "2.0.0"
-sp-api = "2.0.0"
-frame-system-rpc-runtime-api = "2.0.0"
-sp-core = "2.0.0"
-sp-blockchain = "2.0.0"
-sp-transaction-pool = "2.0.0"
-sp-block-builder = "2.0.0"
-sc-rpc-api = "0.8.0"
+sp-runtime = {version = "2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-api = {version="2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+frame-system-rpc-runtime-api = {version="2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-core = {version = "2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-blockchain = {version = "2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-transaction-pool = {version = "2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sp-block-builder = {version = "2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-rpc-api = {version = "0.8.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 
 [dev-dependencies]
 #substrate-test-runtime-client = "2.0.0"
-sp-tracing = "2.0.0"
-sc-transaction-pool = { version = "2.0.0"}
+sp-tracing = {version = "2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
+sc-transaction-pool = { version = "2.0.0", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }


### PR DESCRIPTION
Implementing approach suggested by Substrate Builders Program. Now we are using explicit dependencies to our own substrate fork 
https://github.com/mangata-finance/substrate

There is a dedicated script included `dev_manifest.sh` that temporary updates the `Cargo.toml` and allows for simultaneous development in  both node and forked substrate repository.

```
./scripts/dev_manifest.sh ../substrate
```

also with that change, we officially migrated to substrate v2.0.1 :tada: 