### PR TITLE
Fixed and Unit tested.

### DIFF
--- a/pallets/xyk/src/lib.rs
+++ b/pallets/xyk/src/lib.rs
@@ -459,23 +459,41 @@ impl<T: Trait> Module<T> {
         name.extend_from_slice(LIQUIDITY_TOKEN_IDENTIFIER);
         name.extend_from_slice(HEX_INDICATOR);
         for bytes in liquidity_asset_id.to_be_bytes().iter() {
-            name.push(((bytes >> 4) as u8).saturating_add(48u8));
-            name.push(((bytes & 0b0000_1111) as u8).saturating_add(48u8));
+            match (bytes >> 4) as u8 {
+                x @ 0u8 ..=9u8 => name.push(x.saturating_add(48u8)),
+                x => name.push(x.saturating_add(55u8)),
+            }
+            match (bytes & 0b0000_1111) as u8 {
+                x @ 0u8 ..=9u8 => name.push(x.saturating_add(48u8)),
+                x => name.push(x.saturating_add(55u8)),
+            }
         }
 
         let mut symbol: Vec<u8> = Vec::<u8>::new();
         symbol.extend_from_slice(TOKEN_SYMBOL);
         symbol.extend_from_slice(HEX_INDICATOR);
         for bytes in first_asset_id.to_be_bytes().iter() {
-            symbol.push(((bytes >> 4) as u8).saturating_add(48u8));
-            symbol.push(((bytes & 0b0000_1111) as u8).saturating_add(48u8));
+            match (bytes >> 4) as u8 {
+                x @ 0u8 ..=9u8 => symbol.push(x.saturating_add(48u8)),
+                x => symbol.push(x.saturating_add(55u8)),
+            }
+            match (bytes & 0b0000_1111) as u8 {
+                x @ 0u8 ..=9u8 => symbol.push(x.saturating_add(48u8)),
+                x => symbol.push(x.saturating_add(55u8)),
+            }
         }
         symbol.extend_from_slice(TOKEN_SYMBOL_SEPARATOR);
         symbol.extend_from_slice(TOKEN_SYMBOL);
         symbol.extend_from_slice(HEX_INDICATOR);
         for bytes in second_asset_id.to_be_bytes().iter() {
-            symbol.push(((bytes >> 4) as u8).saturating_add(48u8));
-            symbol.push(((bytes & 0b0000_1111) as u8).saturating_add(48u8));
+            match (bytes >> 4) as u8 {
+                x @ 0u8 ..=9u8 => symbol.push(x.saturating_add(48u8)),
+                x => symbol.push(x.saturating_add(55u8)),
+            }
+            match (bytes & 0b0000_1111) as u8 {
+                x @ 0u8 ..=9u8 => symbol.push(x.saturating_add(48u8)),
+                x => symbol.push(x.saturating_add(55u8)),
+            }
         }
 
         let mut description: Vec<u8> = Vec::<u8>::new();

--- a/pallets/xyk/src/lib.rs
+++ b/pallets/xyk/src/lib.rs
@@ -460,11 +460,11 @@ impl<T: Trait> Module<T> {
         name.extend_from_slice(HEX_INDICATOR);
         for bytes in liquidity_asset_id.to_be_bytes().iter() {
             match (bytes >> 4) as u8 {
-                x @ 0u8 ..=9u8 => name.push(x.saturating_add(48u8)),
+                x @ 0u8..=9u8 => name.push(x.saturating_add(48u8)),
                 x => name.push(x.saturating_add(55u8)),
             }
             match (bytes & 0b0000_1111) as u8 {
-                x @ 0u8 ..=9u8 => name.push(x.saturating_add(48u8)),
+                x @ 0u8..=9u8 => name.push(x.saturating_add(48u8)),
                 x => name.push(x.saturating_add(55u8)),
             }
         }
@@ -474,11 +474,11 @@ impl<T: Trait> Module<T> {
         symbol.extend_from_slice(HEX_INDICATOR);
         for bytes in first_asset_id.to_be_bytes().iter() {
             match (bytes >> 4) as u8 {
-                x @ 0u8 ..=9u8 => symbol.push(x.saturating_add(48u8)),
+                x @ 0u8..=9u8 => symbol.push(x.saturating_add(48u8)),
                 x => symbol.push(x.saturating_add(55u8)),
             }
             match (bytes & 0b0000_1111) as u8 {
-                x @ 0u8 ..=9u8 => symbol.push(x.saturating_add(48u8)),
+                x @ 0u8..=9u8 => symbol.push(x.saturating_add(48u8)),
                 x => symbol.push(x.saturating_add(55u8)),
             }
         }
@@ -487,11 +487,11 @@ impl<T: Trait> Module<T> {
         symbol.extend_from_slice(HEX_INDICATOR);
         for bytes in second_asset_id.to_be_bytes().iter() {
             match (bytes >> 4) as u8 {
-                x @ 0u8 ..=9u8 => symbol.push(x.saturating_add(48u8)),
+                x @ 0u8..=9u8 => symbol.push(x.saturating_add(48u8)),
                 x => symbol.push(x.saturating_add(55u8)),
             }
             match (bytes & 0b0000_1111) as u8 {
-                x @ 0u8 ..=9u8 => symbol.push(x.saturating_add(48u8)),
+                x @ 0u8..=9u8 => symbol.push(x.saturating_add(48u8)),
                 x => symbol.push(x.saturating_add(55u8)),
             }
         }

--- a/pallets/xyk/src/tests.rs
+++ b/pallets/xyk/src/tests.rs
@@ -148,7 +148,7 @@ fn set_info_should_work_with_small_numbers() {
         const N: u32 = 12345u32;
 
         for _ in 0..N {
-        XykStorage::create_new_token(&acc_id, amount);
+            XykStorage::create_new_token(&acc_id, amount);
         }
 
         XykStorage::create_pool(
@@ -172,7 +172,6 @@ fn set_info_should_work_with_small_numbers() {
     });
 }
 
-
 #[test]
 #[ignore]
 fn set_info_should_work_with_large_numbers() {
@@ -183,7 +182,7 @@ fn set_info_should_work_with_large_numbers() {
         const N: u32 = 1524501234u32;
 
         for _ in 0..N {
-        XykStorage::create_new_token(&acc_id, amount);
+            XykStorage::create_new_token(&acc_id, amount);
         }
 
         XykStorage::create_pool(

--- a/pallets/xyk/src/tests.rs
+++ b/pallets/xyk/src/tests.rs
@@ -140,6 +140,74 @@ fn set_info_should_work() {
 }
 
 #[test]
+fn set_info_should_work_with_small_numbers() {
+    new_test_ext().execute_with(|| {
+        // creating asset with assetId 0 and minting to accountId 2
+        let acc_id: u64 = 2;
+        let amount: u128 = 1000000000000000000000;
+        const N: u32 = 12345u32;
+
+        for _ in 0..N {
+        XykStorage::create_new_token(&acc_id, amount);
+        }
+
+        XykStorage::create_pool(
+            Origin::signed(2),
+            15,
+            40000000000000000000,
+            12233,
+            60000000000000000000,
+        )
+        .unwrap();
+
+        assert_eq!(
+            <assets_info::Module<Test>>::get_info(N),
+            assets_info::AssetInfo {
+                name: Some(b"LiquidityPoolToken0x00003039".to_vec()),
+                symbol: Some(b"TKN0x0000000F-TKN0x00002FC9".to_vec()),
+                description: Some(b"Generated Info for Liquidity Pool Token".to_vec()),
+                decimals: Some(18u32),
+            }
+        );
+    });
+}
+
+
+#[test]
+#[ignore]
+fn set_info_should_work_with_large_numbers() {
+    new_test_ext().execute_with(|| {
+        // creating asset with assetId 0 and minting to accountId 2
+        let acc_id: u64 = 2;
+        let amount: u128 = 1000000000000000000000;
+        const N: u32 = 1524501234u32;
+
+        for _ in 0..N {
+        XykStorage::create_new_token(&acc_id, amount);
+        }
+
+        XykStorage::create_pool(
+            Origin::signed(2),
+            15000000,
+            40000000000000000000,
+            12233000,
+            60000000000000000000,
+        )
+        .unwrap();
+
+        assert_eq!(
+            <assets_info::Module<Test>>::get_info(1524501234u32),
+            assets_info::AssetInfo {
+                name: Some(b"LiquidityPoolToken0x5ADE0AF2".to_vec()),
+                symbol: Some(b"TKN0x00E4E1C0-TKN0x00BAA928".to_vec()),
+                description: Some(b"Generated Info for Liquidity Pool Token".to_vec()),
+                decimals: Some(18u32),
+            }
+        );
+    });
+}
+
+#[test]
 fn buy_and_burn_sell_mangata() {
     new_test_ext().execute_with(|| {
         initialize_buy_and_burn();


### PR DESCRIPTION
The asset info for liquidity asset is now as intended as per https://github.com/mangata-finance/wiki/wiki/Liquidity-Token-Info-Format

Potentially "unbreaking" changes.