### PR TITLE
bump substrate fork version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.1](https://github.com/mangata-finance/mangata-node/compare/v0.1.0...v0.1.1) (2021-09-09)
+- Fixing mutlinode setup
+- Passing already shuffled extrinsics instead of doing so at runtime (due to no easy way to inject shuffling seed without Header modifications)
+
 ## 0.1.0 (2021-08-17)
 
 - Added SemVer scripts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,7 +1257,7 @@ dependencies = [
 [[package]]
 name = "extrinsic-info-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -1272,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "extrinsic-shuffler"
 version = "0.8.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "extrinsic-info-runtime-api",
@@ -1400,7 +1400,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1408,7 +1408,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1444,7 +1444,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "extrinsic-shuffler",
  "frame-support",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1499,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1510,7 +1510,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1532,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1562,7 +1562,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3774,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3826,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3869,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3891,7 +3891,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "pallet-random-seed"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3936,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4001,7 +4001,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4029,7 +4029,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4065,7 +4065,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4083,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4890,7 +4890,7 @@ dependencies = [
 [[package]]
 name = "random-seed-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "pallet-random-seed",
  "sp-api",
@@ -5207,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "bytes 0.5.6",
  "derive_more",
@@ -5235,7 +5235,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "extrinsic-info-runtime-api",
  "futures 0.3.5",
@@ -5261,7 +5261,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "extrinsic-info-runtime-api",
  "extrinsic-shuffler",
@@ -5286,7 +5286,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5303,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5314,7 +5314,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5399,7 +5399,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5429,7 +5429,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5440,7 +5440,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "extrinsic-shuffler",
@@ -5488,7 +5488,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5501,7 +5501,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5524,7 +5524,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "log",
  "sc-client-api",
@@ -5538,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "lazy_static",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "log",
@@ -5583,7 +5583,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5616,7 +5616,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "finality-grandpa",
@@ -5653,7 +5653,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -5671,7 +5671,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "hex",
@@ -5687,7 +5687,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5706,7 +5706,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5760,7 +5760,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5775,7 +5775,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -5815,7 +5815,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5824,7 +5824,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -5856,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "futures 0.1.29",
  "jsonrpc-core",
@@ -5898,7 +5898,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "directories",
@@ -5963,7 +5963,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5977,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5998,7 +5998,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "erased-serde",
  "log",
@@ -6017,7 +6017,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6038,7 +6038,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "log",
@@ -6455,7 +6455,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6470,7 +6470,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6482,7 +6482,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6494,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6507,7 +6507,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6519,7 +6519,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6530,7 +6530,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6542,7 +6542,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "log",
@@ -6559,7 +6559,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "serde",
  "serde_json",
@@ -6568,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -6594,7 +6594,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -6613,7 +6613,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6634,7 +6634,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6678,7 +6678,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6687,7 +6687,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6697,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6708,7 +6708,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6724,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6734,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "sp-ignore-tx"
 version = "2.0.0"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6746,7 +6746,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -6758,7 +6758,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -6781,7 +6781,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6792,7 +6792,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6804,7 +6804,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6815,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "backtrace",
  "log",
@@ -6834,7 +6834,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "serde",
  "sp-core",
@@ -6843,7 +6843,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6865,7 +6865,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -6881,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6893,7 +6893,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "serde",
  "serde_json",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6915,7 +6915,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6925,7 +6925,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "hash-db",
  "log",
@@ -6946,12 +6946,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6964,7 +6964,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6978,7 +6978,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6991,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "derive_more",
  "futures 0.3.5",
@@ -7006,7 +7006,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7020,7 +7020,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7032,7 +7032,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7044,7 +7044,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7207,7 +7207,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "async-std",
  "derive_more",
@@ -7221,7 +7221,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "2.0.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "futures 0.3.5",
  "substrate-test-utils-derive",
@@ -7231,7 +7231,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.8.1"
-source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#5b0a05f075a92ffe941b6e4871303c5f2276496b"
+source = "git+https://github.com/mangata-finance/substrate?branch=mangata-dev#6b0e3729b608e9c92710a28b9d46d1450b203656"
 dependencies = [
  "proc-macro-crate",
  "quote",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 homepage = 'https://substrate.dev'
 license = 'Unlicense'
 name = 'mangata-node'
-version = '0.1.0'
+version = '0.1.1'
 
 [[bin]]
 name = 'mangata-node'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mangata-node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": "https://github.com/mangata-finance/mangata-node.git",
   "author": "Mangata Finance",
   "license": "GPL-3.0",


### PR DESCRIPTION
version 0.1.1
- moves extrinsic shuffling from runtime to native code