### PR TITLE
Feature/encryption nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.3.0](https://github.com/mangata-finance/mangata-node/compare/v0.2.0...v0.3.0) (2021-10-05)
+
 ## [0.2.0](https://github.com/mangata-finance/mangata-node/compare/v0.1.0...v0.2.0) (2021-09-15)
 - extend block header with extra field seed
 - store shuffling seed inside header instead of storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ## [0.3.0](https://github.com/mangata-finance/mangata-node/compare/v0.2.0...v0.3.0) (2021-10-05)
+- Added encryption nonces for doubly and singly encrypted calls. This changes the TxnRegistryDetails type used in storage. And adds a field to the two unsigned extrinsics to be used by the collator.
+- Added events. Upgraded existing events to contain more info.
 
 ## [0.2.0](https://github.com/mangata-finance/mangata-node/compare/v0.1.0...v0.2.0) (2021-09-15)
 - extend block header with extra field seed

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 homepage = 'https://substrate.dev'
 license = 'Unlicense'
 name = 'mangata-node'
-version = '0.2.0'
+version = '0.3.0'
 
 [[bin]]
 name = 'mangata-node'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mangata-node",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "repository": "https://github.com/mangata-finance/mangata-node.git",
   "author": "Mangata Finance",
   "license": "GPL-3.0",

--- a/pallets/encrypted-transactions/src/lib.rs
+++ b/pallets/encrypted-transactions/src/lib.rs
@@ -74,7 +74,7 @@ pub struct TxnRegistryDetails<AccountId, Index> {
     pub singly_encrypted_call: Option<Vec<u8>>,
     pub decrypted_call: Option<Vec<u8>>,
     // TODO
-    // Maybe length constriant encryption nonce to 16 bytes 
+    // Maybe length constriant encryption nonce to 16 bytes
     pub doubly_encrypted_nonce: Option<Vec<u8>>,
     pub singly_encrypted_nonce: Option<Vec<u8>>,
 }
@@ -227,7 +227,7 @@ decl_module! {
         #[weight = 10_000]
         fn submit_decrypted_transaction(origin, identifier: T::Hash, decrypted_call: Vec<u8>, singly_encrypted_nonce: Vec<u8>, weight: Weight) -> DispatchResult{
             ensure_none(origin)?;
-            
+
             let mut txn_registry_details = TxnRegistry::<T>::get(identifier).ok_or_else(|| Error::<T>::TxnDoesNotExistsInRegistry)?;
             SinglyEncryptedQueue::<T>::mutate(&txn_registry_details.executor, |vec_hash| {vec_hash.retain(|x| *x!=identifier)});
             ExecutedTxnRecord::<T>::mutate(T::Index::from(<pallet_session::Module<T>>::current_index()), &txn_registry_details.user, |vec_hash| {vec_hash.push(identifier)});
@@ -235,14 +235,14 @@ decl_module! {
             txn_registry_details.decrypted_call = Some(decrypted_call.clone());
             txn_registry_details.singly_encrypted_nonce = Some(singly_encrypted_nonce);
 
-            TxnRegistry::<T>::insert(identifier, &txn_registry_details);            
+            TxnRegistry::<T>::insert(identifier, &txn_registry_details);
 
             Self::deposit_event(RawEvent::DecryptedTransactionSubmitted(txn_registry_details.user.clone(), txn_registry_details.nonce, identifier));
 
             let calls: Vec<Box<<T as Trait>::Call>> = Decode::decode(&mut &decrypted_call[..]).map_err(|_| DispatchError::from(Error::<T>::CallDeserilizationFailed))?;
 
             Module::<T>::execute_calls(RawOrigin::Root.into(), calls, txn_registry_details.user, identifier, txn_registry_details.nonce, weight)?;
-            
+
             Ok(())
         }
 


### PR DESCRIPTION
Added encryption nonces and events.

API breaking changes:
TxnRegistryDetails has now been modified to be:
```
pub struct TxnRegistryDetails<AccountId, Index> {
    pub doubly_encrypted_call: Vec<u8>,
    pub user: AccountId,
    pub nonce: Index,
    pub weight: Weight,
    pub builder: AccountId,
    pub executor: AccountId,
    pub singly_encrypted_call: Option<Vec<u8>>,
    pub decrypted_call: Option<Vec<u8>>,
    pub doubly_encrypted_nonce: Option<Vec<u8>>,
    pub singly_encrypted_nonce: Option<Vec<u8>>,
}
```