### PR TITLE
MultiTokenParachainStaking - Use PairedOrLiquidityToken to add or rem…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5604,7 +5604,6 @@ dependencies = [
 [[package]]
 name = "parachain-staking"
 version = "3.0.0"
-source = "git+https://github.com/mangata-finance/moonbeam.git?branch=mangata-dev-v4#aeb22f9474277463dac39e2b952b3ef0a7326f3b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,13 @@ members = [
 pallet-xyk = { path = "./pallets/xyk" }
 mangata-primitives = {path = "./primitives/mangata"}
 
+# [patch."https://github.com/mangata-finance/moonbeam"]
+# parachain-staking = {path = "../moonbeam/pallets/parachain-staking"}
+
+# [patch."https://github.com/mangata-finance/open-runtime-module-library"]
+# orml-tokens = { path = "../open-runtime-module-library/tokens" }
+# orml-traits = { path = "../open-runtime-module-library/traits" }
+
 # [patch."https://github.com/paritytech/substrate"]
 # sp-debug-derive = { git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev-v4" }
 # sp-tasks = { git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev-v4" }

--- a/pallets/xyk/src/lib.rs
+++ b/pallets/xyk/src/lib.rs
@@ -1860,6 +1860,11 @@ pub trait Valuate {
         + From<TokenId>
         + Into<TokenId>;
 
+    fn get_liquidity_asset(
+        first_asset_id: Self::CurrencyId,
+        second_asset_id: Self::CurrencyId,
+    ) -> Result<TokenId, DispatchError>;
+
     fn get_liquidity_token_mga_pool(
         liquidity_token_id: Self::CurrencyId,
     ) -> Result<(Self::CurrencyId, Self::CurrencyId), DispatchError>;
@@ -1882,6 +1887,13 @@ impl<T: Config> Valuate for Pallet<T> {
     type Balance = Balance;
 
     type CurrencyId = TokenId;
+
+    fn get_liquidity_asset(
+        first_asset_id: Self::CurrencyId,
+        second_asset_id: Self::CurrencyId,
+    ) -> Result<TokenId, DispatchError> {
+        Pallet::<T>::get_liquidity_asset(first_asset_id, second_asset_id)
+    }
 
     fn get_liquidity_token_mga_pool(
         liquidity_token_id: Self::CurrencyId,


### PR DESCRIPTION
Added get_liquidity_asset to Valuate trait to support, https://github.com/mangata-finance/moonbeam/pull/2, PairedOrLiquidityToken enum to add or remove staking tokens from the registry.

No API changes besides the ones in the staking pallet.