### PR TITLE
Fix/dual validator chainspec

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -103,6 +103,10 @@ pub fn development_config() -> ChainSpec {
 				vec![(
 					get_account_id_from_seed::<sr25519::Public>("Alice"),
 					get_collator_keys_from_seed("Alice"),
+				),
+				(
+					get_account_id_from_seed::<sr25519::Public>("Bob"),
+					get_collator_keys_from_seed("Bob"),
 				)],
 				// Initial relay account
 				get_account_id_from_seed::<sr25519::Public>("Relay"),
@@ -240,6 +244,10 @@ pub fn local_testnet_config() -> ChainSpec {
 				vec![(
 					get_account_id_from_seed::<sr25519::Public>("Alice"),
 					get_collator_keys_from_seed("Alice"),
+				),
+				(
+					get_account_id_from_seed::<sr25519::Public>("Bob"),
+					get_collator_keys_from_seed("Bob"),
 				)],
 				// Initial relay account
 				get_account_id_from_seed::<sr25519::Public>("Relay"),


### PR DESCRIPTION
Fixed buggy chainspec to work with dual validators from genesis
initial_authorities was missing Bob. So only Alice was collating initially, now both Alice and Bob will.

No api changes.