### PR TITLE
skip publish if no build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -263,7 +263,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.ref == 'refs/heads/develop' && 
-      !contains(github.event.pull_request.labels.*.name, 'skip-publish')
+      !contains(github.event.pull_request.labels.*.name, 'skip-publish') &&
+      !github.event.inputs.skipBuild
     #if: "!contains(github.event.pull_request.labels.*.name, 'skip-publish') && ${{ github.event_name == 'push'}} && github.event.pull_request.merged == true"
     #if: # its a push to develop.
     steps:


### PR DESCRIPTION
Fix the case for manual run skipping build  \-> hence no publish.

https://github.com/mangata\-finance/mangata\-node/actions/runs/1740760803
