### PR TITLE
smaller devops improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
           ./docker-cargo.sh test --features=runtime-benchmarks,enable-trading
-          ./docker-cargo/release/mangata-node benchmark --chain kusama-mainnet --execution wasm --wasm-execution compiled --extrinsic '*' --pallet 'pallet-xyk' --template ./templates/module-weight-template.hbs
+          ./docker-cargo.sh benchmark --chain kusama-mainnet --execution wasm --wasm-execution compiled --extrinsic '*' --pallet 'pallet-xyk' --template ./templates/module-weight-template.hbs
 
   build-runtime-benchmarks:
     name: Build runtime benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,7 @@ jobs:
       TEST_SUDO_NAME: ${{ secrets.E2E_TEST_SUDO_NAME }}
       MANGATA_NODE_VERSION: ${{ github.sha }}
       E2EBRANCHNAME: 'main'
-      PARACHAIN_DOCKER_IMAGE: "${{ github.event.inputs.parachainDocker || 'mangatasolutions/mangata-node:rococo-e2e-${{ github.sha }}"
+      PARACHAIN_DOCKER_IMAGE: "${{ github.event.inputs.parachainDocker || 'mangatasolutions/mangata-node:rococo-e2e-${{ github.sha }} }}"
     steps:
     ####IDK, but this is neccesary for reports
       -
@@ -499,7 +499,7 @@ jobs:
         run: make -C devops/parachain stop
 
   publish:
-    needs: [rustfmt-check, unit-test, clippy-check, build-rococo, build-kusama, e2e-test]
+    needs: [rustfmt-check, unit-test, clippy-check, build-rococo, build-kusama, e2e-test, build-runtime-benchmarks, run-benchmark-tests]
     runs-on: ubuntu-latest
     if: |
       github.ref == 'refs/heads/develop' && 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,57 @@ jobs:
       #     path: ut-results.xml
       #     reporter: jest-junit
 
+  run-benchmark-tests:
+    name: Unit test
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Pull builder image
+        run: |
+          docker pull ${{ env.DOCKER_BUILDER_IMAGE }}
+      -
+        name: Run unit tests
+        run: |
+          ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
+          ./docker-cargo.sh test --features=runtime-benchmarks,enable-trading
+          ./docker-cargo/release/mangata-node benchmark --chain kusama-mainnet --execution wasm --wasm-execution compiled --extrinsic '*' --pallet 'pallet-xyk' --template ./templates/module-weight-template.hbs
+
+  build-runtime-benchmarks:
+    name: Unit test
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Pull builder image
+        run: |
+          docker pull ${{ env.DOCKER_BUILDER_IMAGE }}
+      -
+        name: Run unit tests
+        run: |
+          ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
+          ./docker-cargo.sh build --release --features=runtime-benchmarks,enable-trading
+
 
   build-rococo:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         name: Run unit tests
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh test -- -Z unstable-options --format json --report-time
+          ./docker-cargo.sh -j2 test -- -Z unstable-options --format json --report-time
           # |cargo2junit | tee ut-results.xml
           # sed -i '/<testsuite.*\/>$/d' ut-results.xml
           # sed -i 's/<testsuites>/<testsuites time="0">/g' ut-results.xml
@@ -146,7 +146,7 @@ jobs:
         name: Run benchamrks
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh test --features=runtime-benchmarks,enable-trading
+          ./docker-cargo.sh -j2 test --features=runtime-benchmarks,enable-trading
 
   run-benchmarks:
     name: Run runtime benchmarks
@@ -171,7 +171,7 @@ jobs:
         name: Build benchmarks
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh build --release --features=runtime-benchmarks,enable-trading
+          ./docker-cargo.sh build -j2 --release --features=runtime-benchmarks,enable-trading
           ./docker-cargo/release/mangata-node benchmark --chain kusama-mainnet --execution wasm --wasm-execution compiled --extrinsic '*' --pallet 'pallet-xyk' --template ./templates/module-weight-template.hbs
 
   build-rococo:
@@ -204,7 +204,7 @@ jobs:
         name: Build node binary
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh build --release --features=enable-trading,mangata-rococo
+          ./docker-cargo.sh build -j2 --release --features=enable-trading,mangata-rococo
       -
         name: Calculate wasm checksum
         run: >
@@ -270,7 +270,7 @@ jobs:
         name: Build node binary
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh build --release --features=enable-trading,mangata-rococo
+          ./docker-cargo.sh build -j2 --release --features=enable-trading,mangata-rococo
       -
         name: Build node img
         env:
@@ -320,7 +320,7 @@ jobs:
         name: Build node binary
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh build --release --features=enable-trading,mangata-kusama
+          ./docker-cargo.sh build -j2 --release --features=enable-trading,mangata-kusama
       -
         name: Calculate wasm checksum
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           ./docker-cargo.sh test --features=runtime-benchmarks,enable-trading
 
   run-benchmarks:
-    name: Build runtime benchmarks
+    name: Run runtime benchmarks
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
           WASM: "docker-cargo/release/wbuild/mangata-rococo-runtime/mangata_rococo_runtime.compact.compressed.wasm"
         run: >
           ./scripts/build-image.sh ${DOCKER_IMAGE_GIT_SHA_TAG} ${DOCKER_IMAGE_LATEST_TAG} &&
-          docker save ${DOCKER_IMAGE_GIT_SHA_TAG} -o rococo-docker-e2e-${{ github.sha }}.tar
+          docker save ${DOCKER_IMAGE_LATEST_TAG} -o rococo-docker-e2e-${{ github.sha }}.tar
       -
         name: Upload docker img artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
           WASM: "docker-cargo/release/wbuild/mangata-rococo-runtime/mangata_rococo_runtime.compact.compressed.wasm"
         run: >
           ./scripts/build-image.sh ${{ env.DOCKER_IMAGE_GIT_SHA_TAG }} ${{ env.DOCKER_IMAGE_LATEST_TAG }} &&
-          docker save ${DOCKER_IMAGE_TAG} -o rococo-docker-${{ github.sha }}.tar
+          docker save ${DOCKER_IMAGE_GIT_SHA_TAG} -o rococo-docker-${{ github.sha }}.tar
       -
         name: Upload docker img artifact
         uses: actions/upload-artifact@v2
@@ -275,13 +275,14 @@ jobs:
       -
         name: Build node img
         env:
-          DOCKER_IMAGE_TAG: "mangatasolutions/mangata-node:rococo-e2e-${{ github.sha }}"
+          DOCKER_IMAGE_GIT_SHA_TAG: "mangatasolutions/mangata-node:rococo-e2e-${{ github.sha }}"
+          DOCKER_IMAGE_LATEST_TAG: "mangatasolutions/mangata-node:rococo-e2e-latest"
           SKIP_BUILD: 1
           NODE_BINARY: "docker-cargo/release/mangata-node"
           WASM: "docker-cargo/release/wbuild/mangata-rococo-runtime/mangata_rococo_runtime.compact.compressed.wasm"
         run: >
-          ./scripts/build-image.sh ${DOCKER_IMAGE_TAG} &&
-          docker save ${DOCKER_IMAGE_TAG} -o rococo-docker-e2e-${{ github.sha }}.tar
+          ./scripts/build-image.sh ${DOCKER_IMAGE_GIT_SHA_TAG} ${DOCKER_IMAGE_LATEST_TAG} &&
+          docker save ${DOCKER_IMAGE_GIT_SHA_TAG} -o rococo-docker-e2e-${{ github.sha }}.tar
       -
         name: Upload docker img artifact
         uses: actions/upload-artifact@v2
@@ -338,7 +339,7 @@ jobs:
           WASM: "docker-cargo/release/wbuild/mangata-kusama-runtime/mangata_kusama_runtime.compact.compressed.wasm"
         run: >
           ./scripts/build-image.sh ${{ env.DOCKER_IMAGE_GIT_SHA_TAG }} ${{ env.DOCKER_IMAGE_LATEST_TAG }} &&
-          docker save ${DOCKER_IMAGE_TAG} -o kusama-docker-${{ github.sha }}.tar
+          docker save ${DOCKER_IMAGE_GIT_SHA_TAG} -o kusama-docker-${{ github.sha }}.tar
       -
         name: Upload docker img artifact
         uses: actions/upload-artifact@v2
@@ -369,7 +370,7 @@ jobs:
       TEST_SUDO_NAME: ${{ secrets.E2E_TEST_SUDO_NAME }}
       MANGATA_NODE_VERSION: ${{ github.sha }}
       E2EBRANCHNAME: 'main'
-      PARACHAIN_DOCKER_IMAGE: "${{ github.event.inputs.parachainDocker || 'mangatasolutions/mangata-node:rococo-e2e-${{ github.sha }} }}"
+      PARACHAIN_DOCKER_IMAGE: "${{ github.event.inputs.parachainDocker || 'mangatasolutions/mangata-node:rococo-e2e-latest' }}"
     steps:
     ####IDK, but this is neccesary for reports
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,9 +147,8 @@ jobs:
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
           ./docker-cargo.sh test --features=runtime-benchmarks,enable-trading
-          ./docker-cargo.sh benchmark --chain kusama-mainnet --execution wasm --wasm-execution compiled --extrinsic '*' --pallet 'pallet-xyk' --template ./templates/module-weight-template.hbs
 
-  build-runtime-benchmarks:
+  run-benchmarks:
     name: Build runtime benchmarks
     runs-on: ubuntu-latest
     steps:
@@ -173,7 +172,7 @@ jobs:
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
           ./docker-cargo.sh build --release --features=runtime-benchmarks,enable-trading
-
+          ./docker-cargo/release/mangata-node benchmark --chain kusama-mainnet --execution wasm --wasm-execution compiled --extrinsic '*' --pallet 'pallet-xyk' --template ./templates/module-weight-template.hbs
 
   build-rococo:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         name: Run unit tests
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh -j2 test -- -Z unstable-options --format json --report-time
+          ./docker-cargo.sh test -j2 -- -Z unstable-options --format json --report-time
           # |cargo2junit | tee ut-results.xml
           # sed -i '/<testsuite.*\/>$/d' ut-results.xml
           # sed -i 's/<testsuites>/<testsuites time="0">/g' ut-results.xml
@@ -146,7 +146,7 @@ jobs:
         name: Run benchamrks
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh -j2 test --features=runtime-benchmarks,enable-trading
+          ./docker-cargo.sh test -j2 --features=runtime-benchmarks,enable-trading
 
   run-benchmarks:
     name: Run runtime benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       #     path: ut-results.xml
       #     reporter: jest-junit
 
-  run-benchmark-tests:
+  run-benchmarks-tests:
     name: Run benchmark tests
     runs-on: ubuntu-latest
     steps:
@@ -495,7 +495,7 @@ jobs:
         run: make -C devops/parachain stop
 
   publish:
-    needs: [rustfmt-check, unit-test, clippy-check, build-rococo, build-kusama, e2e-test, build-runtime-benchmarks, run-benchmark-tests]
+    needs: [rustfmt-check, unit-test, clippy-check, build-rococo, build-kusama, e2e-test, run-benchmarks, run-benchmarks-tests]
     runs-on: ubuntu-latest
     if: |
       github.ref == 'refs/heads/develop' && 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,12 +216,13 @@ jobs:
       -
         name: Build node img
         env:
-          DOCKER_IMAGE_TAG: "mangatasolutions/mangata-node:rococo-${{ github.sha }}"
+          DOCKER_IMAGE_GIT_SHA_TAG: "mangatasolutions/mangata-node:rococo-${{ github.sha }}"
+          DOCKER_IMAGE_LATEST_TAG: "mangatasolutions/mangata-node:rococo-${{ github.sha }}"
           SKIP_BUILD: 1
           NODE_BINARY: "docker-cargo/release/mangata-node"
           WASM: "docker-cargo/release/wbuild/mangata-rococo-runtime/mangata_rococo_runtime.compact.compressed.wasm"
         run: >
-          ./scripts/build-image.sh ${DOCKER_IMAGE_TAG} &&
+          ./scripts/build-image.sh ${{ env.DOCKER_IMAGE_GIT_SHA_TAG }} ${{ env.DOCKER_IMAGE_LATEST_TAG }} &&
           docker save ${DOCKER_IMAGE_TAG} -o rococo-docker-${{ github.sha }}.tar
       -
         name: Upload docker img artifact
@@ -330,12 +331,13 @@ jobs:
       -
         name: Build node img
         env:
-          DOCKER_IMAGE_TAG: "mangatasolutions/mangata-node:kusama-${{ github.sha }}"
+          DOCKER_IMAGE_GIT_SHA_TAG: "mangatasolutions/mangata-node:kusama-${{ github.sha }}"
+          DOCKER_IMAGE_LATEST_TAG: "mangatasolutions/mangata-node:kusama-${{ github.sha }}"
           SKIP_BUILD: 1
           NODE_BINARY: "docker-cargo/release/mangata-node"
           WASM: "docker-cargo/release/wbuild/mangata-kusama-runtime/mangata_kusama_runtime.compact.compressed.wasm"
         run: >
-          ./scripts/build-image.sh ${DOCKER_IMAGE_TAG} &&
+          ./scripts/build-image.sh ${{ env.DOCKER_IMAGE_GIT_SHA_TAG }} ${{ env.DOCKER_IMAGE_LATEST_TAG }} &&
           docker save ${DOCKER_IMAGE_TAG} -o kusama-docker-${{ github.sha }}.tar
       -
         name: Upload docker img artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,7 @@ jobs:
       TEST_SUDO_NAME: ${{ secrets.E2E_TEST_SUDO_NAME }}
       MANGATA_NODE_VERSION: ${{ github.sha }}
       E2EBRANCHNAME: 'main'
-      PARACHAIN_DOCKER_IMAGE: "${{ github.event.inputs.parachainDocker || 'mangatasolutions/mangata-node:latest' }}"
+      PARACHAIN_DOCKER_IMAGE: "${{ github.event.inputs.parachainDocker || 'mangatasolutions/mangata-node:rococo-e2e-${{ github.sha }}"
     steps:
     ####IDK, but this is neccesary for reports
       -
@@ -431,7 +431,9 @@ jobs:
         run: make -C devops/parachain stop
 
       - name: Start mangata-node parachain
-        run: ENV=rococo PARACHAIN_DOCKER_IMAGE=mangatasolutions/mangata-node:rococo-e2e-${{ github.sha }} make -C devops/parachain start 
+        env:
+          ENV: rococo
+        run: make -C devops/parachain start
 
       - name: Install dependencies
         working-directory: e2eTests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,6 @@ jobs:
       -
         name: Run clippy
         run: |
-          docker pull mangatasolutions/node-builder:0.1
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
           ./docker-cargo.sh clippy -p pallet-xyk -p pallet-assets-info -p pallet-bridge
 
@@ -111,7 +110,6 @@ jobs:
         name: Run unit tests
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          docker pull mangatasolutions/node-builder:0.1
           ./docker-cargo.sh test -- -Z unstable-options --format json --report-time
           # |cargo2junit | tee ut-results.xml
           # sed -i '/<testsuite.*\/>$/d' ut-results.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       #     reporter: jest-junit
 
   run-benchmark-tests:
-    name: Unit test
+    name: Run benchmark tests
     runs-on: ubuntu-latest
     steps:
       -
@@ -143,14 +143,14 @@ jobs:
         run: |
           docker pull ${{ env.DOCKER_BUILDER_IMAGE }}
       -
-        name: Run unit tests
+        name: Run benchamrks
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
           ./docker-cargo.sh test --features=runtime-benchmarks,enable-trading
           ./docker-cargo/release/mangata-node benchmark --chain kusama-mainnet --execution wasm --wasm-execution compiled --extrinsic '*' --pallet 'pallet-xyk' --template ./templates/module-weight-template.hbs
 
   build-runtime-benchmarks:
-    name: Unit test
+    name: Build runtime benchmarks
     runs-on: ubuntu-latest
     steps:
       -
@@ -169,7 +169,7 @@ jobs:
         run: |
           docker pull ${{ env.DOCKER_BUILDER_IMAGE }}
       -
-        name: Run unit tests
+        name: Build benchmarks
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
           ./docker-cargo.sh build --release --features=runtime-benchmarks,enable-trading

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4718,6 +4718,7 @@ dependencies = [
  "sp-transaction-pool",
  "sp-trie",
  "structopt",
+ "sub-tokens",
  "substrate-build-script-utils",
  "substrate-prometheus-endpoint",
  "tokio",
@@ -10172,6 +10173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
+
+[[package]]
 name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11315,6 +11322,14 @@ dependencies = [
  "quote",
  "rustversion",
  "syn",
+]
+
+[[package]]
+name = "sub-tokens"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/substrate-debug-kit?branch=master#e12503ab781e913735dc389865a3b8b4a6c6399d"
+dependencies = [
+ "separator",
 ]
 
 [[package]]

--- a/devops/parachain/env/rococo
+++ b/devops/parachain/env/rococo
@@ -1,4 +1,1 @@
-PARA_CHAIN=mangata-rococo-local-testnet
-RELAY_CHAIN=/etc/mangata/rococo-local-0.9.23.json
-PARACHAIN_DOCKER_IMAGE=mangatasolutions/mangata-node:rococo-0.14.0
-RELAYCHAIN_DOCKER_IMAGE=parity/polkadot:v0.9.23
+rococo-0.17.0

--- a/devops/parachain/env/rococo-0.14.0
+++ b/devops/parachain/env/rococo-0.14.0
@@ -1,0 +1,4 @@
+PARA_CHAIN=mangata-rococo-local-testnet
+RELAY_CHAIN=/etc/mangata/rococo-local-0.9.23.json
+PARACHAIN_DOCKER_IMAGE=mangatasolutions/mangata-node:rococo-0.14.0
+RELAYCHAIN_DOCKER_IMAGE=parity/polkadot:v0.9.23

--- a/devops/parachain/env/rococo-0.17.0
+++ b/devops/parachain/env/rococo-0.17.0
@@ -1,0 +1,4 @@
+PARA_CHAIN=mangata-rococo-local-testnet
+RELAY_CHAIN=/etc/mangata/rococo-local-0.9.23.json
+PARACHAIN_DOCKER_IMAGE=mangatasolutions/mangata-node:rococo-0.17.0
+RELAYCHAIN_DOCKER_IMAGE=parity/polkadot:v0.9.23

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -123,6 +123,7 @@ artemis-core = {default-features = false, version = "0.1.1", git = "https://gith
 
 
 [dev-dependencies]
+sub-tokens = { git = "https://github.com/paritytech/substrate-debug-kit", branch = "master" }
 criterion = { version = "0.3.5", features = [ "async_tokio", "html_reports" ] }
 sc-block-builder = { package="sc-block-builder-ver", git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 sp-keyring = { git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -16,24 +16,30 @@ else
     DOCKER_LABEL=${GIT_REV}-dirty
 fi
 
-DOCKER_IMAGE_TAG=${1:-mangatasolutions/mangata-node:local}
+DOCKER_IMAGE_TAG=${@:-mangatasolutions/mangata-node:dev}
+DOCKER_TAGS=""
+
+echo "building docker image ${DOCKER_IMAGE_TAG} with tags:"
+for tag in ${DOCKER_IMAGE_TAG}; do
+    echo \t - ${tag}
+    DOCKER_TAGS="${DOCKER_TAGS} -t ${tag}"
+done
 
 if [ ! -e ${NODE_BINARY} ]; then
-    echo "${NODE_BINARY} not found" >&2
+    echo "env variable 'NODE_BINARY' : ${NODE_BINARY} not found" >&2
     exit -1
 fi
 
 if [ ! -e ${WASM} ]; then
-    echo "${WASM} not found" >&2
+    echo "env variable 'WASM' : ${WASM} not found" >&2
     exit -1
 fi
 
-echo "building docker image ${DOCKER_IMAGE_TAG}"
 
 docker build \
     --build-arg WASM=${WASM} \
     --build-arg NODE_BINARY=${NODE_BINARY} \
     --label "git_rev=${DOCKER_LABEL}" \
-    -t ${DOCKER_IMAGE_TAG} \
+    ${DOCKER_TAGS} \
     -f ${REPO_ROOT}/devops/dockerfiles/node/Dockerfile \
     ${REPO_ROOT}


### PR DESCRIPTION
- remove unnecessary pulls
- add ci steps for compiling & running runtime benchmarks
- add support for setting multiple tags for an image
- assign rococo-latest & kusama-latest tags for built docker images
- use rococo-e2e image as default
