### PR TITLE
Multi use Bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         name: Run benchamrks
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh test -j2 --features=runtime-benchmarks,enable-trading
+          ./docker-cargo.sh test -j2 --features=runtime-benchmarks
 
   run-benchmarks:
     name: Run runtime benchmarks
@@ -171,7 +171,7 @@ jobs:
         name: Build benchmarks
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh build -j2 --release --features=runtime-benchmarks,enable-trading
+          ./docker-cargo.sh build -j2 --release --features=runtime-benchmarks
           ./docker-cargo/release/mangata-node benchmark --chain kusama-mainnet --execution wasm --wasm-execution compiled --extrinsic '*' --pallet 'pallet-xyk' --template ./templates/module-weight-template.hbs
 
   build-rococo:
@@ -204,7 +204,7 @@ jobs:
         name: Build node binary
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh build -j2 --release --features=enable-trading,mangata-rococo
+          ./docker-cargo.sh build -j2 --release --features=mangata-rococo
       -
         name: Calculate wasm checksum
         run: >
@@ -270,7 +270,7 @@ jobs:
         name: Build node binary
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh build -j2 --release --features=enable-trading,mangata-rococo
+          ./docker-cargo.sh build -j2 --release --features=mangata-rococo
       -
         name: Build node img
         env:
@@ -320,7 +320,7 @@ jobs:
         name: Build node binary
         run: |
           ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch || ./docker-cargo.sh fetch
-          ./docker-cargo.sh build -j2 --release --features=enable-trading,mangata-kusama
+          ./docker-cargo.sh build -j2 --release --features=mangata-kusama
       -
         name: Calculate wasm checksum
         run: >

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5705,6 +5705,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "itertools",
  "log",
  "mangata-primitives",
  "mockall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5705,7 +5705,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "itertools",
  "log",
  "mangata-primitives",
  "mockall",

--- a/pallets/bootstrap/Cargo.toml
+++ b/pallets/bootstrap/Cargo.toml
@@ -24,6 +24,7 @@ sp-arithmetic= { git = "https://github.com/mangata-finance/substrate", default-f
 frame-benchmarking = { default-features = false, version = '4.0.0-dev' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 sp-bootstrap = { path = "../../primitives/bootstrap", default-features=false }
 pallet-vesting-mangata = { git = "https://github.com/mangata-finance/substrate", default-features = false, branch = "mangata-dev" }
+itertools = { version="0.10.3", default-features=false }
 
 [dev-dependencies]
 test-case = "2.0.2"

--- a/pallets/bootstrap/Cargo.toml
+++ b/pallets/bootstrap/Cargo.toml
@@ -24,7 +24,6 @@ sp-arithmetic= { git = "https://github.com/mangata-finance/substrate", default-f
 frame-benchmarking = { default-features = false, version = '4.0.0-dev' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 sp-bootstrap = { path = "../../primitives/bootstrap", default-features=false }
 pallet-vesting-mangata = { git = "https://github.com/mangata-finance/substrate", default-features = false, branch = "mangata-dev" }
-itertools = { version="0.10.3", default-features=false }
 
 [dev-dependencies]
 test-case = "2.0.2"

--- a/pallets/bootstrap/Cargo.toml
+++ b/pallets/bootstrap/Cargo.toml
@@ -20,6 +20,7 @@ mangata-primitives = { default-features = false, version = '0.1.0' , path = '../
 sp-core = { default-features = false, version = '4.1.0-dev' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 sp-std = { default-features = false, version = '4.0.0-dev' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 sp-runtime = { git = "https://github.com/mangata-finance/substrate", default-features = false, branch = "mangata-dev" }
+sp-io = { git = "https://github.com/mangata-finance/substrate", default-features = false, branch = "mangata-dev" }
 sp-arithmetic= { git = "https://github.com/mangata-finance/substrate", default-features = false, branch = "mangata-dev" }
 frame-benchmarking = { default-features = false, version = '4.0.0-dev' , git = "https://github.com/mangata-finance/substrate", branch = "mangata-dev" }
 sp-bootstrap = { path = "../../primitives/bootstrap", default-features=false }
@@ -44,6 +45,7 @@ std = [
 	'codec/std',
 	'sp-std/std',
 	'sp-runtime/std',
+	'sp-io/std',
 	'sp-bootstrap/std',
 	'frame-support/std',
 	'frame-system/std',

--- a/pallets/bootstrap/src/benchmarking.rs
+++ b/pallets/bootstrap/src/benchmarking.rs
@@ -32,73 +32,63 @@ const DEFAULT_RATIO: (u128, u128) = (1_u128, 10_000_u128);
 
 benchmarks! {
 
-	start_ido {
+	schedule_bootstrap {
 		assert!(crate::BootstrapSchedule::<T>::get().is_none());
-	}: start_ido(RawOrigin::Root, 123_456_789_u32.into(), 100_000_u32, 100_000_u32, DEFAULT_RATIO)
+		let caller: T::AccountId = whitelisted_caller();
+		let first_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
+		let second_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
+	}: schedule_bootstrap(RawOrigin::Root, first_token_id, second_token_id, 123_456_789_u32.into(), 100_000_u32, 100_000_u32, DEFAULT_RATIO)
 	verify {
 		assert!(crate::BootstrapSchedule::<T>::get().is_some());
 	}
 
 	provision {
 		let caller: T::AccountId = whitelisted_caller();
-		let mut token_id = 0;
-		while token_id < <T as Config>::MGATokenId::get() ||
-		token_id < <T as Config>::KSMTokenId::get() {
-			token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
-		}
+		let first_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
+		let second_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
 		let ksm_provision_amount = 100_000_u128;
 		let mga_provision_amount = ksm_provision_amount * DEFAULT_RATIO.1 / DEFAULT_RATIO.0;
-		<T as Config>::Currency::mint(<T as Config>::MGATokenId::get().into(), &caller, MILION.into()).expect("Token creation failed");
-		<T as Config>::Currency::mint(<T as Config>::KSMTokenId::get().into(), &caller, MILION.into()).expect("Token creation failed");
 
-		BootstrapPallet::<T>::start_ido(RawOrigin::Root.into(), 10_u32.into(), 10_u32, 10_u32, DEFAULT_RATIO).unwrap();
+		BootstrapPallet::<T>::schedule_bootstrap(RawOrigin::Root.into(), first_token_id, second_token_id, 10_u32.into(), 10_u32, 10_u32, DEFAULT_RATIO).unwrap();
 		// jump to public phase
 		BootstrapPallet::<T>::on_initialize(20_u32.into());
-		BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), <T as Config>::MGATokenId::get(), mga_provision_amount).unwrap();
+		BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), second_token_id, mga_provision_amount).unwrap();
 
-	}: provision(RawOrigin::Signed(caller.clone().into()), <T as Config>::KSMTokenId::get(), ksm_provision_amount)
+	}: provision(RawOrigin::Signed(caller.clone().into()), first_token_id, ksm_provision_amount)
 	verify {
-		assert_eq!(BootstrapPallet::<T>::provisions(caller, <T as Config>::KSMTokenId::get()), ksm_provision_amount);
+		assert_eq!(BootstrapPallet::<T>::provisions(caller, first_token_id), ksm_provision_amount);
 	}
-
 
 	provision_vested {
 		let caller: T::AccountId = whitelisted_caller();
-		let mut token_id = 0;
-		while token_id < <T as Config>::MGATokenId::get() ||
-		token_id < <T as Config>::KSMTokenId::get() {
-			token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
-		}
-		<T as Config>::Currency::mint(<T as Config>::MGATokenId::get().into(), &caller, MILION.into()).expect("Token creation failed");
-		<T as Config>::Currency::mint(<T as Config>::KSMTokenId::get().into(), &caller, MILION.into()).expect("Token creation failed");
+		let first_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
+		let second_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
+
 		let ksm_provision_amount = 100_000_u128;
 		let mga_provision_amount = ksm_provision_amount * DEFAULT_RATIO.1 / DEFAULT_RATIO.0;
 
 		let lock = 100_000_000_u128;
 
 		frame_system::Pallet::<T>::set_block_number(1_u32.into());
-		<T as Config>::VestingProvider::lock_tokens(&caller, <T as Config>::KSMTokenId::get().into(), (ksm_provision_amount*2).into(), lock.into()).unwrap();
+		<T as Config>::VestingProvider::lock_tokens(&caller, first_token_id.into(), (ksm_provision_amount*2).into(), lock.into()).unwrap();
 		frame_system::Pallet::<T>::set_block_number(2_u32.into());
 
-		BootstrapPallet::<T>::start_ido(RawOrigin::Root.into(), 10_u32.into(), 10_u32, 10_u32, DEFAULT_RATIO).unwrap();
+		BootstrapPallet::<T>::schedule_bootstrap(RawOrigin::Root.into(), first_token_id, second_token_id, 10_u32.into(), 10_u32, 10_u32, DEFAULT_RATIO).unwrap();
 		// jump to public phase
 		BootstrapPallet::<T>::on_initialize(20_u32.into());
-		BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), <T as Config>::MGATokenId::get(), mga_provision_amount).unwrap();
+		BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), second_token_id, mga_provision_amount).unwrap();
 
-	}: provision_vested(RawOrigin::Signed(caller.clone().into()), <T as Config>::KSMTokenId::get(), ksm_provision_amount)
+		assert_eq!(BootstrapPallet::<T>::vested_provisions(caller.clone(), first_token_id), (0, 0));
+	}: provision_vested(RawOrigin::Signed(caller.clone().into()), first_token_id, ksm_provision_amount)
 	verify {
-		assert_eq!(BootstrapPallet::<T>::vested_provisions(caller, <T as Config>::KSMTokenId::get()).0, (ksm_provision_amount));
+		assert_eq!(BootstrapPallet::<T>::vested_provisions(caller, first_token_id).0, ksm_provision_amount);
 	}
 
 	claim_rewards {
 		let caller: T::AccountId = whitelisted_caller();
-		let mut token_id = 0;
-		while token_id < <T as Config>::MGATokenId::get() ||
-		token_id < <T as Config>::KSMTokenId::get() {
-			token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
-		}
-		<T as Config>::Currency::mint(<T as Config>::MGATokenId::get().into(), &caller, MILION.into()).expect("Token creation failed");
-		<T as Config>::Currency::mint(<T as Config>::KSMTokenId::get().into(), &caller, MILION.into()).expect("Token creation failed");
+		let first_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
+		let second_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
+
 		let ksm_provision_amount = 100_000_u128;
 		let ksm_vested_provision_amount = 300_000_u128;
 		let mga_provision_amount = ksm_provision_amount * DEFAULT_RATIO.1 / DEFAULT_RATIO.0;
@@ -108,25 +98,25 @@ benchmarks! {
 		let total_provision = total_ksm_provision + total_mga_provision;
 		let lock = 150_u128;
 
-		<T as Config>::VestingProvider::lock_tokens(&caller, <T as Config>::KSMTokenId::get().into(), (ksm_provision_amount + ksm_vested_provision_amount).into(), lock.into()).unwrap();
-		<T as Config>::VestingProvider::lock_tokens(&caller, <T as Config>::MGATokenId::get().into(), (mga_provision_amount + mga_vested_provision_amount).into(), lock.into()).unwrap();
+		<T as Config>::VestingProvider::lock_tokens(&caller, first_token_id.into(), (ksm_provision_amount + ksm_vested_provision_amount).into(), lock.into()).unwrap();
+		<T as Config>::VestingProvider::lock_tokens(&caller, second_token_id.into(), (mga_provision_amount + mga_vested_provision_amount).into(), lock.into()).unwrap();
 
-		BootstrapPallet::<T>::start_ido(RawOrigin::Root.into(), 10_u32.into(), 10_u32, 10_u32, DEFAULT_RATIO).unwrap();
+		BootstrapPallet::<T>::schedule_bootstrap(RawOrigin::Root.into(), first_token_id, second_token_id, 10_u32.into(), 10_u32, 10_u32, DEFAULT_RATIO).unwrap();
 		BootstrapPallet::<T>::on_initialize(20_u32.into());
-		BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), <T as Config>::MGATokenId::get(), mga_provision_amount).unwrap();
-		BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), <T as Config>::KSMTokenId::get(), ksm_provision_amount).unwrap();
-		BootstrapPallet::<T>::provision_vested(RawOrigin::Signed(caller.clone().into()).into(), <T as Config>::MGATokenId::get(), mga_vested_provision_amount).unwrap();
-		BootstrapPallet::<T>::provision_vested(RawOrigin::Signed(caller.clone().into()).into(), <T as Config>::KSMTokenId::get(), ksm_vested_provision_amount).unwrap();
+		BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), second_token_id, mga_provision_amount).unwrap();
+		BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), first_token_id, ksm_provision_amount).unwrap();
+		BootstrapPallet::<T>::provision_vested(RawOrigin::Signed(caller.clone().into()).into(), second_token_id, mga_vested_provision_amount).unwrap();
+		BootstrapPallet::<T>::provision_vested(RawOrigin::Signed(caller.clone().into()).into(), first_token_id, ksm_vested_provision_amount).unwrap();
 		BootstrapPallet::<T>::on_initialize(30_u32.into());
 
 		assert_eq!(BootstrapPallet::<T>::phase(), BootstrapPhase::Finished);
-		assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), <T as Config>::KSMTokenId::get()), 0_u128);
-		assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), <T as Config>::MGATokenId::get()), 0_u128);
+		assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), first_token_id), 0_u128);
+		assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), second_token_id), 0_u128);
 		assert_eq!(BootstrapPallet::<T>::valuations(), (total_mga_provision, total_ksm_provision));
-		assert_eq!(BootstrapPallet::<T>::provisions(caller.clone(), <T as Config>::KSMTokenId::get()), (ksm_provision_amount));
-		assert_eq!(BootstrapPallet::<T>::provisions(caller.clone(), <T as Config>::MGATokenId::get()), (mga_provision_amount));
-		assert_eq!(BootstrapPallet::<T>::vested_provisions(caller.clone(), <T as Config>::KSMTokenId::get()), (ksm_vested_provision_amount, lock + 1));
-		assert_eq!(BootstrapPallet::<T>::vested_provisions(caller.clone(), <T as Config>::MGATokenId::get()), (mga_vested_provision_amount, lock + 1));
+		assert_eq!(BootstrapPallet::<T>::provisions(caller.clone(), first_token_id), (ksm_provision_amount));
+		assert_eq!(BootstrapPallet::<T>::provisions(caller.clone(), second_token_id), (mga_provision_amount));
+		assert_eq!(BootstrapPallet::<T>::vested_provisions(caller.clone(), first_token_id), (ksm_vested_provision_amount, lock + 1));
+		assert_eq!(BootstrapPallet::<T>::vested_provisions(caller.clone(), second_token_id), (mga_vested_provision_amount, lock + 1));
 
 	}: claim_rewards(RawOrigin::Signed(caller.clone().into()))
 	verify {
@@ -136,9 +126,55 @@ benchmarks! {
 		let mga_non_vested_rewards = total_provision / 2 / 2 * mga_provision_amount / total_mga_provision;
 		let mga_vested_rewards = total_provision / 2 / 2 * mga_vested_provision_amount / total_mga_provision;
 
-		assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), <T as Config>::KSMTokenId::get()), ksm_vested_rewards + ksm_non_vested_rewards);
-		assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), <T as Config>::MGATokenId::get()), mga_vested_rewards + mga_non_vested_rewards);
+		assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), first_token_id), ksm_vested_rewards + ksm_non_vested_rewards);
+		assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), second_token_id), mga_vested_rewards + mga_non_vested_rewards);
 	}
+
+	// finalize {
+	// 	let caller: T::AccountId = whitelisted_caller();
+	// 	let first_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
+	// 	let second_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
+    //
+	// 	let ksm_provision_amount = 100_000_u128;
+	// 	let ksm_vested_provision_amount = 300_000_u128;
+	// 	let mga_provision_amount = ksm_provision_amount * DEFAULT_RATIO.1 / DEFAULT_RATIO.0;
+	// 	let mga_vested_provision_amount = ksm_vested_provision_amount * DEFAULT_RATIO.1 / DEFAULT_RATIO.0;
+	// 	let total_ksm_provision = ksm_provision_amount + ksm_vested_provision_amount;
+	// 	let total_mga_provision = mga_provision_amount + mga_vested_provision_amount;
+	// 	let total_provision = total_ksm_provision + total_mga_provision;
+	// 	let lock = 150_u128;
+    //
+	// 	<T as Config>::VestingProvider::lock_tokens(&caller, first_token_id.into(), (ksm_provision_amount + ksm_vested_provision_amount).into(), lock.into()).unwrap();
+	// 	<T as Config>::VestingProvider::lock_tokens(&caller, second_token_id.into(), (mga_provision_amount + mga_vested_provision_amount).into(), lock.into()).unwrap();
+    //
+	// 	BootstrapPallet::<T>::schedule_bootstrap(RawOrigin::Root.into(), first_token_id, second_token_id, 10_u32.into(), 10_u32, 10_u32, DEFAULT_RATIO).unwrap();
+	// 	BootstrapPallet::<T>::on_initialize(20_u32.into());
+	// 	BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), second_token_id, mga_provision_amount).unwrap();
+	// 	BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), first_token_id, ksm_provision_amount).unwrap();
+	// 	BootstrapPallet::<T>::provision_vested(RawOrigin::Signed(caller.clone().into()).into(), second_token_id, mga_vested_provision_amount).unwrap();
+	// 	BootstrapPallet::<T>::provision_vested(RawOrigin::Signed(caller.clone().into()).into(), first_token_id, ksm_vested_provision_amount).unwrap();
+	// 	BootstrapPallet::<T>::on_initialize(30_u32.into());
+    //
+	// 	assert_eq!(BootstrapPallet::<T>::phase(), BootstrapPhase::Finished);
+	// 	assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), first_token_id), 0_u128);
+	// 	assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), second_token_id), 0_u128);
+	// 	assert_eq!(BootstrapPallet::<T>::valuations(), (total_mga_provision, total_ksm_provision));
+	// 	assert_eq!(BootstrapPallet::<T>::provisions(caller.clone(), first_token_id), (ksm_provision_amount));
+	// 	assert_eq!(BootstrapPallet::<T>::provisions(caller.clone(), second_token_id), (mga_provision_amount));
+	// 	assert_eq!(BootstrapPallet::<T>::vested_provisions(caller.clone(), first_token_id), (ksm_vested_provision_amount, lock + 1));
+	// 	assert_eq!(BootstrapPallet::<T>::vested_provisions(caller.clone(), second_token_id), (mga_vested_provision_amount, lock + 1));
+    //
+	// }: finalize(RawOrigin::Signed(caller.clone().into()))
+	// verify {
+	// 	let (total_mga_provision, total_ksm_provision) = BootstrapPallet::<T>::valuations();
+	// 	let ksm_non_vested_rewards = total_provision / 2 / 2 * ksm_provision_amount / total_ksm_provision;
+	// 	let ksm_vested_rewards = total_provision / 2 / 2 * ksm_vested_provision_amount / total_ksm_provision;
+	// 	let mga_non_vested_rewards = total_provision / 2 / 2 * mga_provision_amount / total_mga_provision;
+	// 	let mga_vested_rewards = total_provision / 2 / 2 * mga_vested_provision_amount / total_mga_provision;
+    //
+	// 	assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), first_token_id), ksm_vested_rewards + ksm_non_vested_rewards);
+	// 	assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), second_token_id), mga_vested_rewards + mga_non_vested_rewards);
+	// }
 
 	impl_benchmark_test_suite!(BootstrapPallet, crate::mock::new_test_ext(), crate::mock::Test)
 }

--- a/pallets/bootstrap/src/benchmarking.rs
+++ b/pallets/bootstrap/src/benchmarking.rs
@@ -130,51 +130,39 @@ benchmarks! {
 		assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), second_token_id), mga_vested_rewards + mga_non_vested_rewards);
 	}
 
-	// finalize {
-	// 	let caller: T::AccountId = whitelisted_caller();
-	// 	let first_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
-	// 	let second_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
-    //
-	// 	let ksm_provision_amount = 100_000_u128;
-	// 	let ksm_vested_provision_amount = 300_000_u128;
-	// 	let mga_provision_amount = ksm_provision_amount * DEFAULT_RATIO.1 / DEFAULT_RATIO.0;
-	// 	let mga_vested_provision_amount = ksm_vested_provision_amount * DEFAULT_RATIO.1 / DEFAULT_RATIO.0;
-	// 	let total_ksm_provision = ksm_provision_amount + ksm_vested_provision_amount;
-	// 	let total_mga_provision = mga_provision_amount + mga_vested_provision_amount;
-	// 	let total_provision = total_ksm_provision + total_mga_provision;
-	// 	let lock = 150_u128;
-    //
-	// 	<T as Config>::VestingProvider::lock_tokens(&caller, first_token_id.into(), (ksm_provision_amount + ksm_vested_provision_amount).into(), lock.into()).unwrap();
-	// 	<T as Config>::VestingProvider::lock_tokens(&caller, second_token_id.into(), (mga_provision_amount + mga_vested_provision_amount).into(), lock.into()).unwrap();
-    //
-	// 	BootstrapPallet::<T>::schedule_bootstrap(RawOrigin::Root.into(), first_token_id, second_token_id, 10_u32.into(), 10_u32, 10_u32, DEFAULT_RATIO).unwrap();
-	// 	BootstrapPallet::<T>::on_initialize(20_u32.into());
-	// 	BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), second_token_id, mga_provision_amount).unwrap();
-	// 	BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), first_token_id, ksm_provision_amount).unwrap();
-	// 	BootstrapPallet::<T>::provision_vested(RawOrigin::Signed(caller.clone().into()).into(), second_token_id, mga_vested_provision_amount).unwrap();
-	// 	BootstrapPallet::<T>::provision_vested(RawOrigin::Signed(caller.clone().into()).into(), first_token_id, ksm_vested_provision_amount).unwrap();
-	// 	BootstrapPallet::<T>::on_initialize(30_u32.into());
-    //
-	// 	assert_eq!(BootstrapPallet::<T>::phase(), BootstrapPhase::Finished);
-	// 	assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), first_token_id), 0_u128);
-	// 	assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), second_token_id), 0_u128);
-	// 	assert_eq!(BootstrapPallet::<T>::valuations(), (total_mga_provision, total_ksm_provision));
-	// 	assert_eq!(BootstrapPallet::<T>::provisions(caller.clone(), first_token_id), (ksm_provision_amount));
-	// 	assert_eq!(BootstrapPallet::<T>::provisions(caller.clone(), second_token_id), (mga_provision_amount));
-	// 	assert_eq!(BootstrapPallet::<T>::vested_provisions(caller.clone(), first_token_id), (ksm_vested_provision_amount, lock + 1));
-	// 	assert_eq!(BootstrapPallet::<T>::vested_provisions(caller.clone(), second_token_id), (mga_vested_provision_amount, lock + 1));
-    //
-	// }: finalize(RawOrigin::Signed(caller.clone().into()))
-	// verify {
-	// 	let (total_mga_provision, total_ksm_provision) = BootstrapPallet::<T>::valuations();
-	// 	let ksm_non_vested_rewards = total_provision / 2 / 2 * ksm_provision_amount / total_ksm_provision;
-	// 	let ksm_vested_rewards = total_provision / 2 / 2 * ksm_vested_provision_amount / total_ksm_provision;
-	// 	let mga_non_vested_rewards = total_provision / 2 / 2 * mga_provision_amount / total_mga_provision;
-	// 	let mga_vested_rewards = total_provision / 2 / 2 * mga_vested_provision_amount / total_mga_provision;
-    //
-	// 	assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), first_token_id), ksm_vested_rewards + ksm_non_vested_rewards);
-	// 	assert_eq!(BootstrapPallet::<T>::claimed_rewards(caller.clone(), second_token_id), mga_vested_rewards + mga_non_vested_rewards);
-	// }
+	finalize {
+		let caller: T::AccountId = whitelisted_caller();
+		let first_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
+		let second_token_id = <T as Config>::Currency::create(&caller, MILION.into()).expect("Token creation failed").into();
+
+		let ksm_provision_amount = 100_000_u128;
+		let ksm_vested_provision_amount = 300_000_u128;
+		let mga_provision_amount = ksm_provision_amount * DEFAULT_RATIO.1 / DEFAULT_RATIO.0;
+		let mga_vested_provision_amount = ksm_vested_provision_amount * DEFAULT_RATIO.1 / DEFAULT_RATIO.0;
+		let total_ksm_provision = ksm_provision_amount + ksm_vested_provision_amount;
+		let total_mga_provision = mga_provision_amount + mga_vested_provision_amount;
+		let total_provision = total_ksm_provision + total_mga_provision;
+		let lock = 150_u128;
+
+		<T as Config>::VestingProvider::lock_tokens(&caller, first_token_id.into(), (ksm_provision_amount + ksm_vested_provision_amount).into(), lock.into()).unwrap();
+		<T as Config>::VestingProvider::lock_tokens(&caller, second_token_id.into(), (mga_provision_amount + mga_vested_provision_amount).into(), lock.into()).unwrap();
+
+		BootstrapPallet::<T>::schedule_bootstrap(RawOrigin::Root.into(), first_token_id, second_token_id, 10_u32.into(), 10_u32, 10_u32, DEFAULT_RATIO).unwrap();
+		BootstrapPallet::<T>::on_initialize(20_u32.into());
+		BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), second_token_id, mga_provision_amount).unwrap();
+		BootstrapPallet::<T>::provision(RawOrigin::Signed(caller.clone().into()).into(), first_token_id, ksm_provision_amount).unwrap();
+		BootstrapPallet::<T>::provision_vested(RawOrigin::Signed(caller.clone().into()).into(), second_token_id, mga_vested_provision_amount).unwrap();
+		BootstrapPallet::<T>::provision_vested(RawOrigin::Signed(caller.clone().into()).into(), first_token_id, ksm_vested_provision_amount).unwrap();
+		BootstrapPallet::<T>::on_initialize(30_u32.into());
+
+		BootstrapPallet::<T>::claim_rewards(RawOrigin::Signed(caller.clone().into()).into());
+		BootstrapPallet::<T>::claim_rewards(RawOrigin::Signed(caller.clone().into()).into());
+		assert_eq!(BootstrapPallet::<T>::phase(), BootstrapPhase::Finished);
+
+	}: finalize(RawOrigin::Root, None)
+	verify {
+		assert_eq!(BootstrapPallet::<T>::phase(), BootstrapPhase::BeforeStart);
+	}
 
 	impl_benchmark_test_suite!(BootstrapPallet, crate::mock::new_test_ext(), crate::mock::Test)
 }

--- a/pallets/bootstrap/src/lib.rs
+++ b/pallets/bootstrap/src/lib.rs
@@ -268,7 +268,7 @@ pub mod pallet {
 		/// - PublicPhase - blocks (ido_start + whitelist_phase_length)..(ido_start + whitelist_phase_length  + public_phase_lenght)
 		#[pallet::weight(T::WeightInfo::start_ido())]
 		#[transactional]
-		pub fn start_ido(
+		pub fn schedule_bootstrap(
 			origin: OriginFor<T>,
 			ido_start: T::BlockNumber,
 			whitelist_phase_length: u32,

--- a/pallets/bootstrap/src/lib.rs
+++ b/pallets/bootstrap/src/lib.rs
@@ -294,8 +294,14 @@ pub mod pallet {
 			ensure!(Phase::<T>::get() == BootstrapPhase::BeforeStart, Error::<T>::AlreadyStarted);
 			ensure!(first_token_id != second_token_id, Error::<T>::SameToken);
 
-			ensure!(!T::Currency::total_issuance(first_token_id.into()).is_zero(), Error::<T>::TokenIdDoesNotExists);
-			ensure!(!T::Currency::total_issuance(second_token_id.into()).is_zero(), Error::<T>::TokenIdDoesNotExists);
+			ensure!(
+				!T::Currency::total_issuance(first_token_id.into()).is_zero(),
+				Error::<T>::TokenIdDoesNotExists
+			);
+			ensure!(
+				!T::Currency::total_issuance(second_token_id.into()).is_zero(),
+				Error::<T>::TokenIdDoesNotExists
+			);
 
 			ensure!(
 				ido_start > frame_system::Pallet::<T>::block_number(),
@@ -348,7 +354,7 @@ pub mod pallet {
 			Self::do_claim_rewards(&sender)
 		}
 
-		#[pallet::weight(T::WeightInfo::claim_rewards())]
+		#[pallet::weight(T::WeightInfo::finalize().saturating_add(T::DbWeight::get().reads_writes(1, 1) * Into::<u64>::into(limit.unwrap_or_default())))]
 		#[transactional]
 		pub fn finalize(origin: OriginFor<T>, mut limit: Option<u32>) -> DispatchResult {
 			ensure_root(origin)?;

--- a/pallets/bootstrap/src/lib.rs
+++ b/pallets/bootstrap/src/lib.rs
@@ -107,13 +107,21 @@ pub mod pallet {
 					// TODO: include cost of pool_create call
 					T::DbWeight::get().reads_writes(15, 13)
 				} else if n >= public_start {
-					Phase::<T>::put(BootstrapPhase::Public);
-					log!(info, "starting public phase");
-					T::DbWeight::get().reads_writes(2, 1)
+					if phase != BootstrapPhase::Public {
+						Phase::<T>::put(BootstrapPhase::Public);
+						log!(info, "starting public phase");
+						T::DbWeight::get().reads_writes(2, 1)
+					} else {
+						T::DbWeight::get().reads(2)
+					}
 				} else if n >= whitelist_start {
-					log!(info, "starting whitelist phase");
-					Phase::<T>::put(BootstrapPhase::Whitelist);
-					T::DbWeight::get().reads_writes(2, 1)
+					if phase != BootstrapPhase::Whitelist {
+						log!(info, "starting whitelist phase");
+						Phase::<T>::put(BootstrapPhase::Whitelist);
+						T::DbWeight::get().reads_writes(2, 1)
+					} else {
+						T::DbWeight::get().reads(2)
+					}
 				} else {
 					T::DbWeight::get().reads(2)
 				}

--- a/pallets/bootstrap/src/lib.rs
+++ b/pallets/bootstrap/src/lib.rs
@@ -363,7 +363,17 @@ pub mod pallet {
 			);
 
 			Phase::<T>::put(BootstrapPhase::BeforeStart);
-			MintedLiquidity::<T>::kill();
+			let (liq_token_id, _) = MintedLiquidity::<T>::take();
+			let balance = T::Currency::free_balance(liq_token_id.into(), &Self::vault_address());
+			if balance > 0_u128.into() {
+				T::Currency::transfer(
+					liq_token_id.into(),
+					&Self::vault_address(),
+					&T::TreasuryPalletId::get().into_account(),
+					balance,
+					ExistenceRequirement::AllowDeath,
+				)?;
+			}
 			Valuations::<T>::kill();
 			BootstrapSchedule::<T>::kill();
 			Ok(().into())

--- a/pallets/bootstrap/src/lib.rs
+++ b/pallets/bootstrap/src/lib.rs
@@ -134,6 +134,9 @@ pub mod pallet {
 		#[pallet::constant]
 		type KSMTokenId: Get<TokenId>;
 
+		#[pallet::constant]
+		type TreasuryPalletId: Get<PalletId>;
+
 		type VestingProvider: MultiTokenVestingLocks<Self::AccountId>;
 
 		type WeightInfo: WeightInfo;
@@ -316,6 +319,25 @@ pub mod pallet {
 
 		#[pallet::weight(T::WeightInfo::claim_rewards())]
 		#[transactional]
+		pub fn finalize(origin: OriginFor<T>) -> DispatchResult{
+			let sender = ensure_root(origin)?;
+			let (liq_token_id, _) =  MintedLiquidity::<T>::take();
+
+			
+			// T::Currency::transfer_all(liq_token_id, T::TreasuryPalletId::get().into_account())?;
+
+			// Provisions::<T>::kill();
+			// VestedProvisions::<T>::kill();
+			// WhitelistedAccount::<T>::kill();
+			Phase::<T>::put(BootstrapPhase::BeforeStart);
+			Valuations::<T>::kill();
+			BootstrapSchedule::<T>::kill();
+			// ClaimedRewards::<T>::kill();
+			Ok(().into())
+		}
+
+		#[pallet::weight(T::WeightInfo::claim_rewards())]
+		#[transactional]
 		pub fn claim_rewards_for_account(
 			origin: OriginFor<T>,
 			account: T::AccountId,
@@ -356,6 +378,8 @@ pub mod pallet {
 		NothingToClaim,
 		/// no rewards to claim
 		WrongRatio,
+		/// no rewards to claim
+		BootstrapNotReadyToBeFinished,
 	}
 
 	#[pallet::event]

--- a/pallets/bootstrap/src/lib.rs
+++ b/pallets/bootstrap/src/lib.rs
@@ -134,12 +134,6 @@ pub mod pallet {
 		type PoolCreateApi: PoolCreateApi<AccountId = Self::AccountId>;
 
 		#[pallet::constant]
-		type MGATokenId: Get<TokenId>;
-
-		#[pallet::constant]
-		type KSMTokenId: Get<TokenId>;
-
-		#[pallet::constant]
 		type TreasuryPalletId: Get<PalletId>;
 
 		type VestingProvider: MultiTokenVestingLocks<Self::AccountId>;

--- a/pallets/bootstrap/src/lib.rs
+++ b/pallets/bootstrap/src/lib.rs
@@ -10,7 +10,7 @@ use frame_support::{
 		child,
 		generator::{StorageDoubleMap as GStorageDoubleMap, StorageMap as GStorageMap},
 	},
-	traits::{ExistenceRequirement, Get},
+	traits::{Contains, ExistenceRequirement, Get},
 	transactional, PalletId,
 };
 use frame_system::{ensure_root, ensure_signed, pallet_prelude::OriginFor};
@@ -695,5 +695,12 @@ impl<T: Config> Pallet<T> {
 
 	fn second_token_id() -> TokenId {
 		ActivePair::<T>::get().map(|(_, second)| second).unwrap_or(0_u32)
+	}
+}
+
+impl<T: Config> Contains<(TokenId, TokenId)> for Pallet<T> {
+	fn contains(pair: &(TokenId, TokenId)) -> bool {
+		pair == &(Self::first_token_id(), Self::second_token_id()) ||
+			pair == &(Self::second_token_id(), Self::first_token_id())
 	}
 }

--- a/pallets/bootstrap/src/lib.rs
+++ b/pallets/bootstrap/src/lib.rs
@@ -21,7 +21,7 @@ use scale_info::TypeInfo;
 use sp_arithmetic::helpers_128bit::multiply_by_rational;
 use sp_bootstrap::PoolCreateApi;
 use sp_core::U256;
-use sp_runtime::traits::{AccountIdConversion, CheckedAdd, Zero};
+use sp_runtime::traits::{AccountIdConversion, CheckedAdd};
 use sp_std::prelude::*;
 
 #[cfg(test)]
@@ -647,10 +647,6 @@ impl<T: Config> Pallet<T> {
 			.ok_or(Error::<T>::MathOverflow)?
 			.checked_add(ksm_rewards_vested)
 			.ok_or(Error::<T>::MathOverflow)?;
-
-		if total_rewards_claimed.is_zero() {
-			return Err(Error::<T>::NothingToClaim.into())
-		}
 
 		Self::claim_rewards_from_single_currency(
 			&who,

--- a/pallets/bootstrap/src/lib.rs
+++ b/pallets/bootstrap/src/lib.rs
@@ -18,7 +18,7 @@ use sp_arithmetic::helpers_128bit::multiply_by_rational;
 use sp_bootstrap::PoolCreateApi;
 use sp_core::U256;
 use sp_io::KillStorageResult;
-use sp_runtime::traits::{AccountIdConversion, CheckedAdd};
+use sp_runtime::traits::{AccountIdConversion, CheckedAdd, Zero};
 use sp_std::prelude::*;
 
 pub mod migrations;
@@ -32,7 +32,6 @@ mod benchmarking;
 mod tests;
 
 pub mod weights;
-use sp_core::storage::ChildInfo;
 pub use weights::WeightInfo;
 
 pub use pallet::*;
@@ -293,6 +292,10 @@ pub mod pallet {
 			ensure_root(origin)?;
 
 			ensure!(Phase::<T>::get() == BootstrapPhase::BeforeStart, Error::<T>::AlreadyStarted);
+			ensure!(first_token_id != second_token_id, Error::<T>::SameToken);
+
+			ensure!(!T::Currency::total_issuance(first_token_id.into()).is_zero(), Error::<T>::TokenIdDoesNotExists);
+			ensure!(!T::Currency::total_issuance(second_token_id.into()).is_zero(), Error::<T>::TokenIdDoesNotExists);
 
 			ensure!(
 				ido_start > frame_system::Pallet::<T>::block_number(),
@@ -451,6 +454,10 @@ pub mod pallet {
 		WrongRatio,
 		/// no rewards to claim
 		BootstrapNotReadyToBeFinished,
+		/// Tokens used in bootstrap cannot be the same
+		SameToken,
+		/// Token does not exists
+		TokenIdDoesNotExists,
 	}
 
 	#[pallet::event]

--- a/pallets/bootstrap/src/migrations.rs
+++ b/pallets/bootstrap/src/migrations.rs
@@ -1,0 +1,72 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+pub mod v1 {
+	use super::*;
+	use crate::log;
+	use frame_support::traits::OnRuntimeUpgrade;
+
+	/// Trivial migration which makes the roles of each pool optional.
+	///
+	/// Note: The depositor is not optional since he can never change.
+	pub struct MigrateToV1<T>(sp_std::marker::PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for MigrateToV1<T> {
+		fn on_runtime_upgrade() -> Weight {
+			let current = Pallet::<T>::current_storage_version();
+			let onchain = Pallet::<T>::on_chain_storage_version();
+
+			log!(
+				info,
+				"Running migration with current storage version {:?} / onchain {:?}",
+				current,
+				onchain
+			);
+
+			if current == 1 && onchain == 0 {
+				// this is safe to execute on any runtime that has a bounded number of pools.
+
+				if Phase::<T>::get() == BootstrapPhase::Finished && ActivePair::<T>::get().is_none()
+				{
+					ActivePair::<T>::put((4_u32, 0_u32));
+					log!(info, "Filled ActivePair with default value");
+					T::DbWeight::get().reads_writes(3, 1)
+				} else {
+					T::DbWeight::get().reads_writes(3, 0)
+				}
+			} else {
+				log!(info, "Migration did not executed. This probably should be removed");
+				T::DbWeight::get().reads(2)
+			}
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<(), &'static str> {
+			log!(info, "Bootstrap::pre_upgrade");
+			assert_eq!(Pallet::<T>::on_chain_storage_version(), 1);
+			Ok(())
+		}
+
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade() -> Result<(), &'static str> {
+			log!(info, "Bootstrap::post_upgrade");
+			assert_eq!(Pallet::<T>::on_chain_storage_version(), 1);
+			Ok(())
+		}
+	}
+}

--- a/pallets/bootstrap/src/mock.rs
+++ b/pallets/bootstrap/src/mock.rs
@@ -20,7 +20,7 @@ use super::*;
 use crate as pallet_bootstrap;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{ConstU128, ConstU32, Contains, Everything},
+	traits::{ConstU128, ConstU32, Contains, Everything, Nothing},
 };
 use mangata_primitives::{Amount, Balance, TokenId};
 use orml_tokens::{MultiTokenCurrency, MultiTokenCurrencyAdapter};
@@ -131,6 +131,7 @@ impl pallet_xyk::Config for Test {
 	type RewardsDistributionPeriod = ConstU32<10000>;
 	type WeightInfo = ();
 	type DisallowedPools = Bootstrap;
+	type DisabledTokens = Nothing;
 	type VestingProvider = Vesting;
 }
 

--- a/pallets/bootstrap/src/mock.rs
+++ b/pallets/bootstrap/src/mock.rs
@@ -190,6 +190,7 @@ impl pallet_bootstrap::Config for Test {
 	type MGATokenId = MGAId;
 	type KSMTokenId = KSMId;
 	type PoolCreateApi = MockPoolCreateApi;
+	type TreasuryPalletId = TreasuryPalletId;
 	type Currency = orml_tokens::MultiTokenCurrencyAdapter<Test>;
 	type VestingProvider = Vesting;
 	type WeightInfo = ();

--- a/pallets/bootstrap/src/mock.rs
+++ b/pallets/bootstrap/src/mock.rs
@@ -130,6 +130,7 @@ impl pallet_xyk::Config for Test {
 	type BuyAndBurnFeePercentage = ConstU128<5>;
 	type RewardsDistributionPeriod = ConstU32<10000>;
 	type WeightInfo = ();
+	type DisallowedPools = Bootstrap;
 	type VestingProvider = Vesting;
 }
 

--- a/pallets/bootstrap/src/mock.rs
+++ b/pallets/bootstrap/src/mock.rs
@@ -201,6 +201,7 @@ impl pallet_bootstrap::Config for Test {
 impl pallet_bootstrap::Config for Test {
 	type Event = Event;
 	type PoolCreateApi = Xyk;
+	type TreasuryPalletId = TreasuryPalletId;
 	type Currency = orml_tokens::MultiTokenCurrencyAdapter<Test>;
 	type VestingProvider = Vesting;
 	type WeightInfo = ();

--- a/pallets/bootstrap/src/mock.rs
+++ b/pallets/bootstrap/src/mock.rs
@@ -187,8 +187,6 @@ mockall::mock! {
 // NOTE: use PoolCreateApi mock for unit testing purposes
 impl pallet_bootstrap::Config for Test {
 	type Event = Event;
-	type MGATokenId = MGAId;
-	type KSMTokenId = KSMId;
 	type PoolCreateApi = MockPoolCreateApi;
 	type TreasuryPalletId = TreasuryPalletId;
 	type Currency = orml_tokens::MultiTokenCurrencyAdapter<Test>;
@@ -200,8 +198,6 @@ impl pallet_bootstrap::Config for Test {
 // NOTE: use Xyk as PoolCreateApi for benchmarking purposes
 impl pallet_bootstrap::Config for Test {
 	type Event = Event;
-	type MGATokenId = MGAId;
-	type KSMTokenId = KSMId;
 	type PoolCreateApi = Xyk;
 	type Currency = orml_tokens::MultiTokenCurrencyAdapter<Test>;
 	type VestingProvider = Vesting;

--- a/pallets/bootstrap/src/tests.rs
+++ b/pallets/bootstrap/src/tests.rs
@@ -184,7 +184,20 @@ fn test_donation_with_more_tokens_than_available() {
 fn test_prevent_provisions_in_before_start_phase() {
 	new_test_ext().execute_with(|| {
 		set_up();
-		Phase::<Test>::put(BootstrapPhase::BeforeStart);
+
+		let pool_exists_mock = MockPoolCreateApi::pool_exists_context();
+		pool_exists_mock.expect().return_const(false);
+
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			100_u32.into(),
+			10,
+			20,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
 
 		assert_err!(
 			Bootstrap::provision(Origin::signed(USER_ID), KSMId::get(), INITIAL_AMOUNT * 2),
@@ -198,7 +211,23 @@ fn test_prevent_provisions_in_before_start_phase() {
 fn test_prevent_provisions_in_finished_phase() {
 	new_test_ext().execute_with(|| {
 		set_up();
+
+		let pool_exists_mock = MockPoolCreateApi::pool_exists_context();
+		pool_exists_mock.expect().return_const(false);
+
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			100_u32.into(),
+			10,
+			20,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
+
 		Phase::<Test>::put(BootstrapPhase::Finished);
+
 		assert_err!(
 			Bootstrap::provision(Origin::signed(USER_ID), KSMId::get(), INITIAL_AMOUNT * 2),
 			Error::<Test>::Unauthorized

--- a/pallets/bootstrap/src/tests.rs
+++ b/pallets/bootstrap/src/tests.rs
@@ -1496,3 +1496,5 @@ fn claim_rewards_even_if_sum_of_rewards_is_zero_because_of_small_provision() {
 		);
 	});
 }
+
+// TODO: test dust is sent to reasury

--- a/pallets/bootstrap/src/tests.rs
+++ b/pallets/bootstrap/src/tests.rs
@@ -33,7 +33,16 @@ fn set_up() {
 fn jump_to_whitelist_phase() {
 	let pool_exists_mock = MockPoolCreateApi::pool_exists_context();
 	pool_exists_mock.expect().return_const(false);
-	Bootstrap::schedule_bootstrap(Origin::root(), 10_u32.into(), 10, 10, DEFAULT_RATIO).unwrap();
+	Bootstrap::schedule_bootstrap(
+		Origin::root(),
+		KSMId::get(),
+		MGAId::get(),
+		10_u32.into(),
+		10,
+		10,
+		DEFAULT_RATIO,
+	)
+	.unwrap();
 	Bootstrap::on_initialize(15_u32.into());
 	assert_eq!(BootstrapPhase::Whitelist, Phase::<Test>::get());
 }
@@ -42,7 +51,16 @@ fn jump_to_public_phase() {
 	let pool_exists_mock = MockPoolCreateApi::pool_exists_context();
 	pool_exists_mock.expect().return_const(false);
 
-	Bootstrap::schedule_bootstrap(Origin::root(), 10_u32.into(), 10, 10, DEFAULT_RATIO).unwrap();
+	Bootstrap::schedule_bootstrap(
+		Origin::root(),
+		KSMId::get(),
+		MGAId::get(),
+		10_u32.into(),
+		10,
+		10,
+		DEFAULT_RATIO,
+	)
+	.unwrap();
 	Bootstrap::on_initialize(25_u32.into());
 	assert_eq!(BootstrapPhase::Public, Phase::<Test>::get());
 }
@@ -257,6 +275,8 @@ fn test_non_root_user_can_not_schedule_bootstrap() {
 		assert_err!(
 			Bootstrap::schedule_bootstrap(
 				Origin::signed(USER_ID),
+				KSMId::get(),
+				MGAId::get(),
 				0_u32.into(),
 				1,
 				1,
@@ -292,7 +312,15 @@ fn test_ido_start_cannot_happen_in_the_past() {
 		set_up();
 		System::set_block_number(1000);
 		assert_err!(
-			Bootstrap::schedule_bootstrap(Origin::root(), 999_u32.into(), 1, 1, DEFAULT_RATIO),
+			Bootstrap::schedule_bootstrap(
+				Origin::root(),
+				KSMId::get(),
+				MGAId::get(),
+				999_u32.into(),
+				1,
+				1,
+				DEFAULT_RATIO
+			),
 			Error::<Test>::BootstrapStartInThePast
 		);
 	});
@@ -305,11 +333,27 @@ fn test_ido_start_can_not_be_initialize_with_0_ratio() {
 		set_up();
 		System::set_block_number(10);
 		assert_err!(
-			Bootstrap::schedule_bootstrap(Origin::root(), 999_u32.into(), 1, 1, (1, 0)),
+			Bootstrap::schedule_bootstrap(
+				Origin::root(),
+				KSMId::get(),
+				MGAId::get(),
+				999_u32.into(),
+				1,
+				1,
+				(1, 0)
+			),
 			Error::<Test>::WrongRatio
 		);
 		assert_err!(
-			Bootstrap::schedule_bootstrap(Origin::root(), 999_u32.into(), 1, 1, (0, 1)),
+			Bootstrap::schedule_bootstrap(
+				Origin::root(),
+				KSMId::get(),
+				MGAId::get(),
+				999_u32.into(),
+				1,
+				1,
+				(0, 1)
+			),
 			Error::<Test>::WrongRatio
 		);
 	});
@@ -321,7 +365,15 @@ fn test_cannot_schedule_bootstrap_with_whitelist_phase_length_equal_zero() {
 	new_test_ext().execute_with(|| {
 		set_up();
 		assert_err!(
-			Bootstrap::schedule_bootstrap(Origin::root(), 100_u32.into(), 0, 1, DEFAULT_RATIO),
+			Bootstrap::schedule_bootstrap(
+				Origin::root(),
+				KSMId::get(),
+				MGAId::get(),
+				100_u32.into(),
+				0,
+				1,
+				DEFAULT_RATIO
+			),
 			Error::<Test>::PhaseLengthCannotBeZero
 		);
 	});
@@ -333,7 +385,15 @@ fn test_cannot_schedule_bootstrap_with_public_phase_length_equal_zero() {
 	new_test_ext().execute_with(|| {
 		set_up();
 		assert_err!(
-			Bootstrap::schedule_bootstrap(Origin::root(), 100_u32.into(), 1, 0, DEFAULT_RATIO),
+			Bootstrap::schedule_bootstrap(
+				Origin::root(),
+				KSMId::get(),
+				MGAId::get(),
+				100_u32.into(),
+				1,
+				0,
+				DEFAULT_RATIO
+			),
 			Error::<Test>::PhaseLengthCannotBeZero
 		);
 	});
@@ -348,16 +408,40 @@ fn test_bootstrap_can_be_modified_only_before_its_started() {
 		let pool_exists_mock = MockPoolCreateApi::pool_exists_context();
 		pool_exists_mock.expect().return_const(false);
 
-		Bootstrap::schedule_bootstrap(Origin::root(), 50_u32.into(), 10, 20, DEFAULT_RATIO)
-			.unwrap();
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			50_u32.into(),
+			10,
+			20,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
 
-		Bootstrap::schedule_bootstrap(Origin::root(), 100_u32.into(), 10, 20, DEFAULT_RATIO)
-			.unwrap();
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			100_u32.into(),
+			10,
+			20,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
 
 		Bootstrap::on_initialize(100_u32.into());
 
 		assert_err!(
-			Bootstrap::schedule_bootstrap(Origin::root(), 100_u32.into(), 10, 20, DEFAULT_RATIO),
+			Bootstrap::schedule_bootstrap(
+				Origin::root(),
+				KSMId::get(),
+				MGAId::get(),
+				100_u32.into(),
+				10,
+				20,
+				DEFAULT_RATIO
+			),
 			Error::<Test>::AlreadyStarted
 		);
 
@@ -383,6 +467,8 @@ fn test_bootstrap_state_transitions() {
 
 		Bootstrap::schedule_bootstrap(
 			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
 			BOOTSTRAP_WHITELIST_START.into(),
 			(BOOTSTRAP_PUBLIC_START - BOOTSTRAP_WHITELIST_START).try_into().unwrap(),
 			(BOOTSTRAP_FINISH - BOOTSTRAP_PUBLIC_START).try_into().unwrap(),
@@ -433,6 +519,8 @@ fn test_bootstrap_state_transitions_when_on_initialized_is_not_called() {
 
 		Bootstrap::schedule_bootstrap(
 			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
 			BOOTSTRAP_WHITELIST_START.into(),
 			(BOOTSTRAP_PUBLIC_START - BOOTSTRAP_WHITELIST_START).try_into().unwrap(),
 			(BOOTSTRAP_FINISH - BOOTSTRAP_PUBLIC_START).try_into().unwrap(),
@@ -455,6 +543,8 @@ fn test_bootstrap_schedule_overflow() {
 		assert_err!(
 			Bootstrap::schedule_bootstrap(
 				Origin::root(),
+				KSMId::get(),
+				MGAId::get(),
 				u64::MAX.into(),
 				u32::MAX,
 				1_u32,
@@ -466,6 +556,8 @@ fn test_bootstrap_schedule_overflow() {
 		assert_err!(
 			Bootstrap::schedule_bootstrap(
 				Origin::root(),
+				KSMId::get(),
+				MGAId::get(),
 				u64::MAX.into(),
 				1_u32,
 				u32::MAX,
@@ -477,6 +569,8 @@ fn test_bootstrap_schedule_overflow() {
 		assert_err!(
 			Bootstrap::schedule_bootstrap(
 				Origin::root(),
+				KSMId::get(),
+				MGAId::get(),
 				u64::MAX.into(),
 				u32::MAX,
 				u32::MAX,
@@ -495,7 +589,15 @@ fn test_do_not_allow_for_creating_starting_bootstrap_for_existing_pool() {
 		pool_exists_mock.expect().return_const(true);
 
 		assert_err!(
-			Bootstrap::schedule_bootstrap(Origin::root(), 100_u32.into(), 10, 10, DEFAULT_RATIO),
+			Bootstrap::schedule_bootstrap(
+				Origin::root(),
+				KSMId::get(),
+				MGAId::get(),
+				100_u32.into(),
+				10,
+				10,
+				DEFAULT_RATIO
+			),
 			Error::<Test>::PoolAlreadyExists
 		);
 	});
@@ -527,8 +629,16 @@ fn test_crate_pool_is_called_with_proper_arguments_after_bootstrap_finish() {
 			.times(1)
 			.return_const(POOL_CREATE_DUMMY_RETURN_VALUE);
 
-		Bootstrap::schedule_bootstrap(Origin::root(), 100_u32.into(), 10, 10, DEFAULT_RATIO)
-			.unwrap();
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			100_u32.into(),
+			10,
+			10,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
 
 		Bootstrap::on_initialize(110_u32.into());
 		Bootstrap::provision(Origin::signed(USER_ID), MGAId::get(), MGA_PROVISON).unwrap();
@@ -546,8 +656,16 @@ fn test_cannot_claim_rewards_when_bootstrap_is_not_finished() {
 		let pool_exists_mock = MockPoolCreateApi::pool_exists_context();
 		pool_exists_mock.expect().return_const(false);
 
-		Bootstrap::schedule_bootstrap(Origin::root(), 100_u32.into(), 10, 10, DEFAULT_RATIO)
-			.unwrap();
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			100_u32.into(),
+			10,
+			10,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
 
 		Bootstrap::on_initialize(100_u32.into());
 		assert_eq!(BootstrapPhase::Whitelist, Phase::<Test>::get());
@@ -588,8 +706,16 @@ fn test_rewards_are_distributed_properly_with_single_user() {
 				Some((id, issuance))
 			});
 
-		Bootstrap::schedule_bootstrap(Origin::root(), 100_u32.into(), 10, 10, DEFAULT_RATIO)
-			.unwrap();
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			100_u32.into(),
+			10,
+			10,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
 
 		Bootstrap::on_initialize(100_u32.into());
 		assert_eq!(BootstrapPhase::Whitelist, Phase::<Test>::get());
@@ -663,8 +789,16 @@ fn test_rewards_are_distributed_properly_with_multiple_user() {
 				Some((id, issuance))
 			});
 
-		Bootstrap::schedule_bootstrap(Origin::root(), 100_u32.into(), 10, 10, DEFAULT_RATIO)
-			.unwrap();
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			100_u32.into(),
+			10,
+			10,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
 
 		Bootstrap::on_initialize(100_u32.into());
 		assert_eq!(BootstrapPhase::Whitelist, Phase::<Test>::get());
@@ -1205,8 +1339,16 @@ fn test_restart_rewards() {
 				Some((id, issuance))
 			});
 
-		Bootstrap::schedule_bootstrap(Origin::root(), 100_u32.into(), 10, 10, DEFAULT_RATIO)
-			.unwrap();
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			100_u32.into(),
+			10,
+			10,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
 		Bootstrap::on_initialize(110_u32.into());
 		Bootstrap::transfer(MGAId::get(), USER_ID.into(), ANOTHER_USER_ID.into(), 500_000).unwrap();
 		Bootstrap::transfer(KSMId::get(), USER_ID.into(), ANOTHER_USER_ID.into(), 500_000).unwrap();
@@ -1247,8 +1389,16 @@ fn test_restart_rewards() {
 		assert_ne!(0, Bootstrap::balance(liq_token_id, ANOTHER_USER_ID));
 
 		Bootstrap::finalize(Origin::root()).unwrap();
-		Bootstrap::schedule_bootstrap(Origin::root(), 200_u32.into(), 10, 10, DEFAULT_RATIO)
-			.unwrap();
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			200_u32.into(),
+			10,
+			10,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
 	});
 }
 
@@ -1274,8 +1424,16 @@ fn claim_rewards_even_if_sum_of_rewards_is_zero_because_of_small_provision() {
 				Some((id, issuance))
 			});
 
-		Bootstrap::schedule_bootstrap(Origin::root(), 100_u32.into(), 10, 10, DEFAULT_RATIO)
-			.unwrap();
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			100_u32.into(),
+			10,
+			10,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
 		Bootstrap::on_initialize(110_u32.into());
 		Bootstrap::transfer(MGAId::get(), USER_ID.into(), ANOTHER_USER_ID.into(), 1).unwrap();
 		Bootstrap::transfer(KSMId::get(), USER_ID.into(), ANOTHER_USER_ID.into(), 1).unwrap();

--- a/pallets/bootstrap/src/tests.rs
+++ b/pallets/bootstrap/src/tests.rs
@@ -20,6 +20,10 @@ const POOL_CREATE_DUMMY_RETURN_VALUE: Option<(TokenId, Balance)> =
 	Some((LIQ_TOKEN_ID, LIQ_TOKEN_AMOUNT));
 
 fn set_up() {
+	// for backwards compatibility
+	ArchivedBootstrap::<mock::Test>::mutate(|v| {
+		v.push(Default::default());
+	});
 	let mga_id = Bootstrap::create_new_token(&USER_ID, INITIAL_AMOUNT);
 	let ksm_id = Bootstrap::create_new_token(&USER_ID, INITIAL_AMOUNT);
 	let dummy_id = Bootstrap::create_new_token(&USER_ID, INITIAL_AMOUNT);
@@ -1437,6 +1441,10 @@ fn test_restart_rewards() {
 #[serial]
 fn claim_rewards_even_if_sum_of_rewards_is_zero_because_of_small_provision() {
 	new_test_ext().execute_with(|| {
+		ArchivedBootstrap::<mock::Test>::mutate(|v| {
+			v.push(Default::default());
+		});
+
 		Bootstrap::create_new_token(&USER_ID, u128::MAX);
 		Bootstrap::create_new_token(&USER_ID, u128::MAX);
 		let liq_token_id = Tokens::next_asset_id();
@@ -1599,7 +1607,8 @@ fn archive_previous_bootstrap_schedules() {
 		Bootstrap::on_initialize(120_u32.into());
 		Bootstrap::claim_rewards(Origin::signed(USER_ID)).unwrap();
 		assert_eq!(0, Bootstrap::archived().len());
-		Bootstrap::finalize(Origin::root(), None).unwrap();
+		Bootstrap::finalize(Origin::root(), Some(1)).unwrap();
+		assert_eq!(0, Bootstrap::provisions(USER_ID, KSMId::get()));
 
 		assert_eq!(1, Bootstrap::archived().len());
 	})

--- a/pallets/bootstrap/src/tests.rs
+++ b/pallets/bootstrap/src/tests.rs
@@ -1497,4 +1497,66 @@ fn claim_rewards_even_if_sum_of_rewards_is_zero_because_of_small_provision() {
 	});
 }
 
-// TODO: test dust is sent to reasury
+#[test]
+#[serial]
+fn transfer_dust_to_treasury() {
+	new_test_ext().execute_with(|| {
+		Bootstrap::create_new_token(&USER_ID, u128::MAX);
+		Bootstrap::create_new_token(&USER_ID, u128::MAX);
+		let liq_token_id = Tokens::next_asset_id();
+
+		let pool_exists_mock = MockPoolCreateApi::pool_exists_context();
+		pool_exists_mock.expect().return_const(false);
+
+		let pool_create_mock = MockPoolCreateApi::pool_create_context();
+		pool_create_mock
+			.expect()
+			.times(1)
+			.returning(move |addr, _, ksm_amount, _, mga_amount| {
+				let issuance = (ksm_amount + mga_amount) / 2;
+				let id = Bootstrap::create_new_token(&addr, issuance);
+				assert_eq!(id, liq_token_id);
+				Some((id, issuance))
+			});
+
+		Bootstrap::schedule_bootstrap(
+			Origin::root(),
+			KSMId::get(),
+			MGAId::get(),
+			100_u32.into(),
+			10,
+			10,
+			DEFAULT_RATIO,
+		)
+		.unwrap();
+		Bootstrap::on_initialize(110_u32.into());
+		Bootstrap::transfer(MGAId::get(), USER_ID.into(), ANOTHER_USER_ID.into(), 1).unwrap();
+		Bootstrap::transfer(KSMId::get(), USER_ID.into(), ANOTHER_USER_ID.into(), 1).unwrap();
+
+		Bootstrap::provision(Origin::signed(USER_ID), MGAId::get(), 1_000_000_000_u128).unwrap();
+		Bootstrap::provision(Origin::signed(ANOTHER_USER_ID), MGAId::get(), 1).unwrap();
+
+		Bootstrap::provision(Origin::signed(USER_ID), KSMId::get(), 100_u128).unwrap();
+
+		Bootstrap::on_initialize(120_u32.into());
+
+		assert_eq!(0, Bootstrap::balance(liq_token_id, USER_ID));
+		assert_eq!(0, Bootstrap::balance(liq_token_id, ANOTHER_USER_ID));
+
+		Bootstrap::claim_rewards(Origin::signed(USER_ID)).unwrap();
+		Bootstrap::claim_rewards(Origin::signed(ANOTHER_USER_ID)).unwrap();
+
+		let before_finalize = Bootstrap::balance(
+			liq_token_id,
+			<mock::Test as Config>::TreasuryPalletId::get().into_account(),
+		);
+		Bootstrap::finalize(Origin::root()).unwrap();
+		let after_finalize = Bootstrap::balance(
+			liq_token_id,
+			<mock::Test as Config>::TreasuryPalletId::get().into_account(),
+		);
+		assert!(after_finalize > before_finalize);
+	});
+}
+
+// TODO: test xyk blocking

--- a/pallets/bootstrap/src/tests.rs
+++ b/pallets/bootstrap/src/tests.rs
@@ -521,8 +521,10 @@ fn test_bootstrap_state_transitions() {
 		Bootstrap::on_initialize(BOOTSTRAP_PUBLIC_START);
 		assert_eq!(Bootstrap::phase(), BootstrapPhase::Public);
 
+		println!("{:?}", Bootstrap::phase());
 		for i in BOOTSTRAP_PUBLIC_START..BOOTSTRAP_FINISH {
 			Bootstrap::on_initialize(i);
+			println!("{:?}", Bootstrap::phase());
 			assert_eq!(Bootstrap::phase(), BootstrapPhase::Public);
 		}
 
@@ -1397,7 +1399,7 @@ fn test_restart_rewards() {
 		)
 		.unwrap();
 
-		assert_err!(Bootstrap::finalize(Origin::root()), Error::<Test>::NotFinishedYet);
+		assert_err!(Bootstrap::finalize(Origin::root(), None), Error::<Test>::NotFinishedYet);
 
 		Bootstrap::on_initialize(120_u32.into());
 
@@ -1408,7 +1410,7 @@ fn test_restart_rewards() {
 
 		// not all rewards claimed
 		assert_err!(
-			Bootstrap::finalize(Origin::root()),
+			Bootstrap::finalize(Origin::root(), None),
 			Error::<Test>::BootstrapNotReadyToBeFinished
 		);
 
@@ -1417,7 +1419,7 @@ fn test_restart_rewards() {
 		assert_ne!(0, Bootstrap::balance(liq_token_id, USER_ID));
 		assert_ne!(0, Bootstrap::balance(liq_token_id, ANOTHER_USER_ID));
 
-		Bootstrap::finalize(Origin::root()).unwrap();
+		Bootstrap::finalize(Origin::root(), None).unwrap();
 		Bootstrap::schedule_bootstrap(
 			Origin::root(),
 			KSMId::get(),
@@ -1551,7 +1553,7 @@ fn transfer_dust_to_treasury() {
 			<mock::Test as Config>::TreasuryPalletId::get().into_account(),
 		);
 
-		Bootstrap::finalize(Origin::root()).unwrap();
+		Bootstrap::finalize(Origin::root(), None).unwrap();
 
 		let after_finalize = Bootstrap::balance(
 			liq_token_id,
@@ -1567,7 +1569,6 @@ fn archive_previous_bootstrap_schedules() {
 	new_test_ext().execute_with(|| {
 		Bootstrap::create_new_token(&USER_ID, u128::MAX);
 		Bootstrap::create_new_token(&USER_ID, u128::MAX);
-		let liq_token_id = Tokens::next_asset_id();
 
 		let pool_exists_mock = MockPoolCreateApi::pool_exists_context();
 		pool_exists_mock.expect().return_const(false);
@@ -1598,7 +1599,7 @@ fn archive_previous_bootstrap_schedules() {
 		Bootstrap::on_initialize(120_u32.into());
 		Bootstrap::claim_rewards(Origin::signed(USER_ID)).unwrap();
 		assert_eq!(0, Bootstrap::archived().len());
-		Bootstrap::finalize(Origin::root()).unwrap();
+		Bootstrap::finalize(Origin::root(), None).unwrap();
 
 		assert_eq!(1, Bootstrap::archived().len());
 	})

--- a/pallets/bootstrap/src/tests.rs
+++ b/pallets/bootstrap/src/tests.rs
@@ -86,7 +86,7 @@ fn test_first_provision_with_ksm_fails() {
 
 		assert_err!(
 			Bootstrap::provision(Origin::signed(USER_ID), KSMId::get(), 1),
-			Error::<Test>::FirstProvisionInMga
+			Error::<Test>::FirstProvisionInSecondTokenId
 		);
 	});
 }

--- a/pallets/bootstrap/src/tests.rs
+++ b/pallets/bootstrap/src/tests.rs
@@ -805,7 +805,6 @@ fn successful_vested_provision_using_vested_tokens_only_when_user_has_both_veste
 		.unwrap();
 
 		let non_vested_initial_amount = Bootstrap::balance(MGAId::get(), USER_ID);
-		let vested_initial_amount = Bootstrap::locked_balance(MGAId::get(), USER_ID);
 
 		Bootstrap::provision_vested(Origin::signed(USER_ID), MGAId::get(), provision_amount)
 			.unwrap();
@@ -1160,16 +1159,7 @@ fn test_multi_provisions(
 #[serial]
 fn test_restart_rewards() {
 	new_test_ext().execute_with(|| {
-		use std::sync::{Arc, Mutex};
 		set_up();
-
-		let provisioned_ev = |id, amount| {
-			crate::mock::Event::Bootstrap(crate::Event::<Test>::Provisioned(id, amount))
-		};
-
-		let rewards_claimed_ev = |id, amount| {
-			crate::mock::Event::Bootstrap(crate::Event::<Test>::RewardsClaimed(id, amount))
-		};
 
 		const USER_KSM_PROVISON: Balance = 15;
 		const USER_MGA_PROVISON: Balance = 400_000;

--- a/pallets/bootstrap/src/tests.rs
+++ b/pallets/bootstrap/src/tests.rs
@@ -1477,10 +1477,10 @@ fn test_restart_bootstrap() {
 		assert!(WhitelistedAccount::<Test>::iter_keys().next().is_none());
 		assert!(ClaimedRewards::<Test>::iter_keys().next().is_none());
 		assert!(ProvisionAccounts::<Test>::iter_keys().next().is_none());
-		assert_eq!(Valuations::<Test>::get(), (0,0));
+		assert_eq!(Valuations::<Test>::get(), (0, 0));
 		assert_eq!(Phase::<Test>::get(), BootstrapPhase::BeforeStart);
 		assert_eq!(BootstrapSchedule::<Test>::get(), None);
-		assert_eq!(MintedLiquidity::<Test>::get(), (0,0));
+		assert_eq!(MintedLiquidity::<Test>::get(), (0, 0));
 		assert_eq!(ActivePair::<Test>::get(), None);
 
 		Bootstrap::schedule_bootstrap(

--- a/pallets/bootstrap/src/tests.rs
+++ b/pallets/bootstrap/src/tests.rs
@@ -212,6 +212,54 @@ fn test_prevent_provisions_in_before_start_phase() {
 
 #[test]
 #[serial]
+fn test_fail_scheudle_bootstrap_with_same_token() {
+	new_test_ext().execute_with(|| {
+		set_up();
+
+		let pool_exists_mock = MockPoolCreateApi::pool_exists_context();
+		pool_exists_mock.expect().return_const(false);
+
+		assert_err!(
+			Bootstrap::schedule_bootstrap(
+				Origin::root(),
+				100,
+				100,
+				100_u32.into(),
+				10,
+				20,
+				DEFAULT_RATIO,
+			),
+			Error::<Test>::SameToken
+		);
+	});
+}
+
+#[test]
+#[serial]
+fn test_prevent_schedule_bootstrap_with_pair_that_does_not_exists() {
+	new_test_ext().execute_with(|| {
+		set_up();
+
+		let pool_exists_mock = MockPoolCreateApi::pool_exists_context();
+		pool_exists_mock.expect().return_const(false);
+
+		assert_err!(
+			Bootstrap::schedule_bootstrap(
+				Origin::root(),
+				100,
+				101,
+				100_u32.into(),
+				10,
+				20,
+				DEFAULT_RATIO,
+			),
+			Error::<Test>::TokenIdDoesNotExists
+		);
+	});
+}
+
+#[test]
+#[serial]
 fn test_prevent_provisions_in_finished_phase() {
 	new_test_ext().execute_with(|| {
 		set_up();

--- a/pallets/bootstrap/src/tests.rs
+++ b/pallets/bootstrap/src/tests.rs
@@ -1398,7 +1398,7 @@ fn test_multi_provisions(
 
 #[test]
 #[serial]
-fn test_restart_rewards() {
+fn test_restart_bootstrap() {
 	new_test_ext().execute_with(|| {
 		set_up();
 
@@ -1472,6 +1472,17 @@ fn test_restart_rewards() {
 		assert_ne!(0, Bootstrap::balance(liq_token_id, ANOTHER_USER_ID));
 
 		Bootstrap::finalize(Origin::root(), None).unwrap();
+		assert!(Provisions::<Test>::iter_keys().next().is_none());
+		assert!(VestedProvisions::<Test>::iter_keys().next().is_none());
+		assert!(WhitelistedAccount::<Test>::iter_keys().next().is_none());
+		assert!(ClaimedRewards::<Test>::iter_keys().next().is_none());
+		assert!(ProvisionAccounts::<Test>::iter_keys().next().is_none());
+		assert_eq!(Valuations::<Test>::get(), (0,0));
+		assert_eq!(Phase::<Test>::get(), BootstrapPhase::BeforeStart);
+		assert_eq!(BootstrapSchedule::<Test>::get(), None);
+		assert_eq!(MintedLiquidity::<Test>::get(), (0,0));
+		assert_eq!(ActivePair::<Test>::get(), None);
+
 		Bootstrap::schedule_bootstrap(
 			Origin::root(),
 			KSMId::get(),

--- a/pallets/bootstrap/src/weights.rs
+++ b/pallets/bootstrap/src/weights.rs
@@ -12,10 +12,11 @@ pub trait WeightInfo {
 	fn provision() -> Weight;
 	fn provision_vested() -> Weight;
 	fn claim_rewards() -> Weight;
+	fn finalize() -> Weight;
 }
 
 
-// For backwards compatibility and tests
+// Dummy values For backwards compatibility and tests
 impl WeightInfo for () {
 	fn start_ido() -> Weight {
 		(23_396_000 as Weight)
@@ -33,6 +34,11 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
 	}
 	fn claim_rewards() -> Weight {
+		(273_011_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(13 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
+	}
+	fn finalize() -> Weight {
 		(273_011_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(13 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(6 as Weight))

--- a/pallets/xyk/Cargo.toml
+++ b/pallets/xyk/Cargo.toml
@@ -43,7 +43,6 @@ serial_test = { version = "0.6.0", default-features = false }
 
 [features]
 default = ['std']
-enable-trading = []
 std = [
     'hex/std',
 	'serde',

--- a/pallets/xyk/src/lib.rs
+++ b/pallets/xyk/src/lib.rs
@@ -283,16 +283,6 @@ mod benchmarking;
 pub mod weights;
 pub use weights::WeightInfo;
 
-#[cfg(not(feature = "enable-trading"))]
-fn is_asset_enabled(asset_id: &TokenId) -> bool {
-	asset_id < &(2 as u32) || asset_id > &(3 as u32)
-}
-
-#[cfg(feature = "enable-trading")]
-fn is_asset_enabled(_asset_id: &TokenId) -> bool {
-	true
-}
-
 type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 #[frame_support::pallet]
 pub mod pallet {
@@ -327,6 +317,7 @@ pub mod pallet {
 		#[pallet::constant]
 		type RewardsDistributionPeriod: Get<u32>;
 		type DisallowedPools: Contains<(TokenId, TokenId)>;
+		type DisabledTokens: Contains<TokenId>;
 		type VestingProvider: MultiTokenVestingLocks<Self::AccountId>;
 		type WeightInfo: WeightInfo;
 	}
@@ -518,7 +509,8 @@ pub mod pallet {
 			let sender = ensure_signed(origin)?;
 
 			ensure!(
-				is_asset_enabled(&first_asset_id) && is_asset_enabled(&second_asset_id),
+				!T::DisabledTokens::contains(&first_asset_id) &&
+					!T::DisabledTokens::contains(&second_asset_id),
 				Error::<T>::FunctionNotAvailableForThisToken
 			);
 
@@ -629,7 +621,8 @@ pub mod pallet {
 			let sender = ensure_signed(origin)?;
 
 			ensure!(
-				is_asset_enabled(&first_asset_id) && is_asset_enabled(&second_asset_id),
+				!T::DisabledTokens::contains(&first_asset_id) &&
+					!T::DisabledTokens::contains(&second_asset_id),
 				Error::<T>::FunctionNotAvailableForThisToken
 			);
 
@@ -1804,7 +1797,8 @@ impl<T: Config> XykFunctionsTrait<T::AccountId> for Pallet<T> {
 		ensure!(!sold_asset_amount.is_zero(), Error::<T>::ZeroAmount,);
 
 		ensure!(
-			is_asset_enabled(&sold_asset_id) && is_asset_enabled(&bought_asset_id),
+			!T::DisabledTokens::contains(&sold_asset_id) &&
+				!T::DisabledTokens::contains(&bought_asset_id),
 			Error::<T>::FunctionNotAvailableForThisToken
 		);
 
@@ -1982,7 +1976,8 @@ impl<T: Config> XykFunctionsTrait<T::AccountId> for Pallet<T> {
 		max_amount_in: Self::Balance,
 	) -> DispatchResult {
 		ensure!(
-			is_asset_enabled(&sold_asset_id) && is_asset_enabled(&bought_asset_id),
+			!T::DisabledTokens::contains(&sold_asset_id) &&
+				!T::DisabledTokens::contains(&bought_asset_id),
 			Error::<T>::FunctionNotAvailableForThisToken
 		);
 
@@ -2315,7 +2310,8 @@ impl<T: Config> XykFunctionsTrait<T::AccountId> for Pallet<T> {
 		let vault = Pallet::<T>::account_id();
 
 		ensure!(
-			is_asset_enabled(&first_asset_id) && is_asset_enabled(&second_asset_id),
+			!T::DisabledTokens::contains(&first_asset_id) &&
+				!T::DisabledTokens::contains(&second_asset_id),
 			Error::<T>::FunctionNotAvailableForThisToken
 		);
 

--- a/pallets/xyk/src/mock.rs
+++ b/pallets/xyk/src/mock.rs
@@ -12,12 +12,9 @@ use sp_runtime::{
 use crate as xyk;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{ConstU128, ConstU32, Contains, Everything},
+	traits::{ConstU128, ConstU32, Contains, Everything, Nothing},
 	PalletId,
 };
-
-#[cfg(feature = "runtime-benchmarks")]
-use frame_support::traits::Nothing;
 
 use frame_system as system;
 use mangata_primitives::{Amount, Balance, TokenId};
@@ -278,6 +275,7 @@ impl Config for Test {
 	type WeightInfo = ();
 	type VestingProvider = Vesting;
 	type DisallowedPools = DummyBlacklistedPool;
+	type DisabledTokens = Nothing;
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -296,6 +294,7 @@ impl Config for Test {
 	type WeightInfo = ();
 	type VestingProvider = Vesting;
 	type DisallowedPools = Nothing;
+	type DisabledTokens = Nothing;
 }
 
 impl<T: Config> Pallet<T> {

--- a/pallets/xyk/src/mock.rs
+++ b/pallets/xyk/src/mock.rs
@@ -15,6 +15,10 @@ use frame_support::{
 	traits::{ConstU128, ConstU32, Contains, Everything},
 	PalletId,
 };
+
+#[cfg(feature = "runtime-benchmarks")]
+use frame_support::traits::Nothing;
+
 use frame_system as system;
 use mangata_primitives::{Amount, Balance, TokenId};
 use orml_tokens::{MultiTokenCurrency, MultiTokenCurrencyAdapter, MultiTokenCurrencyExtended};
@@ -250,6 +254,14 @@ parameter_types! {
 	pub FakeLiquidityMiningIssuanceVault: AccountId = LiquidityMiningIssuanceVaultId::get().into_account();
 }
 
+pub struct DummyBlacklistedPool;
+
+impl Contains<(TokenId, TokenId)> for DummyBlacklistedPool {
+	fn contains(pair: &(TokenId, TokenId)) -> bool {
+		pair == &(1_u32, 9_u32) || pair == &(9_u32, 1_u32)
+	}
+}
+
 #[cfg(not(feature = "runtime-benchmarks"))]
 impl Config for Test {
 	type Event = Event;
@@ -265,6 +277,7 @@ impl Config for Test {
 	type RewardsDistributionPeriod = ConstU32<10000>;
 	type WeightInfo = ();
 	type VestingProvider = Vesting;
+	type DisallowedPools = DummyBlacklistedPool;
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -282,6 +295,7 @@ impl Config for Test {
 	type RewardsDistributionPeriod = ConstU32<10000>;
 	type WeightInfo = ();
 	type VestingProvider = Vesting;
+	type DisallowedPools = Nothing;
 }
 
 impl<T: Config> Pallet<T> {

--- a/pallets/xyk/src/tests.rs
+++ b/pallets/xyk/src/tests.rs
@@ -2671,3 +2671,33 @@ fn PoolCreateApi_pool_create_creates_a_pool() {
 		assert!(<XykStorage as PoolCreateApi>::pool_exists(0_u32.into(), 1_u32.into()));
 	});
 }
+
+#[test]
+fn test_create_blacklisted_pool() {
+	new_test_ext().execute_with(|| {
+		let blaclisted_first_asset_id = 1;
+		let blaclisted_second_asset_id = 9;
+
+		assert_err!(
+			XykStorage::create_pool(
+				Origin::signed(2),
+				blaclisted_first_asset_id,
+				100000000000000,
+				blaclisted_second_asset_id,
+				100000000000000
+			),
+			Error::<Test>::DisallowedPool
+		);
+
+		assert_err!(
+			XykStorage::create_pool(
+				Origin::signed(2),
+				blaclisted_second_asset_id,
+				100000000000000,
+				blaclisted_first_asset_id,
+				100000000000000
+			),
+			Error::<Test>::DisallowedPool
+		);
+	});
+}

--- a/runtime/mangata-kusama/Cargo.toml
+++ b/runtime/mangata-kusama/Cargo.toml
@@ -186,7 +186,9 @@ std = [
 	"pallet-issuance/std",
 	"pallet-vesting-mangata/std",
 	"pallet-crowdloan-rewards/std",
+	"pallet-collective/std",
 	"pallet-elections-phragmen/std",
+	"frame-system-rpc-runtime-api/std",
 
 ]
 
@@ -220,7 +222,6 @@ runtime-benchmarks = [
 	"parachain-staking/runtime-benchmarks",
 	"xcm-asset-registry/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
-	"pallet-collective/runtime-benchmarks",
 	"pallet-elections-phragmen/runtime-benchmarks",
 	"pallet-crowdloan-rewards/runtime-benchmarks",
 	"pallet-utility/runtime-benchmarks",

--- a/runtime/mangata-kusama/Cargo.toml
+++ b/runtime/mangata-kusama/Cargo.toml
@@ -201,10 +201,6 @@ disable-execution = [
 	"frame-executive/disable-execution",
 ]
 
-enable-trading = [
-	"pallet-xyk/enable-trading"
-]
-
 runtime-benchmarks = [
 	"hex-literal",
 	"sp-runtime/runtime-benchmarks",

--- a/runtime/mangata-kusama/src/lib.rs
+++ b/runtime/mangata-kusama/src/lib.rs
@@ -502,7 +502,7 @@ impl pallet_xyk::Config for Runtime {
 	type BuyAndBurnFeePercentage = frame_support::traits::ConstU128<5>;
 	type RewardsDistributionPeriod = frame_support::traits::ConstU32<10000>;
 	type VestingProvider = Vesting;
-	type DisallowedPools = Nothing;
+	type DisallowedPools = Bootstrap;
 	type WeightInfo = weights::pallet_xyk_weights::ModuleWeight<Runtime>;
 }
 
@@ -511,6 +511,7 @@ impl pallet_bootstrap::Config for Runtime {
 	type PoolCreateApi = Xyk;
 	type Currency = orml_tokens::MultiTokenCurrencyAdapter<Runtime>;
 	type VestingProvider = Vesting;
+	type TreasuryPalletId = TreasuryPalletId;
 	type WeightInfo = weights::pallet_bootstrap_weights::ModuleWeight<Runtime>;
 }
 

--- a/runtime/mangata-kusama/src/lib.rs
+++ b/runtime/mangata-kusama/src/lib.rs
@@ -502,6 +502,7 @@ impl pallet_xyk::Config for Runtime {
 	type BuyAndBurnFeePercentage = frame_support::traits::ConstU128<5>;
 	type RewardsDistributionPeriod = frame_support::traits::ConstU32<10000>;
 	type VestingProvider = Vesting;
+	type DisallowedPools = Nothing;
 	type WeightInfo = weights::pallet_xyk_weights::ModuleWeight<Runtime>;
 }
 

--- a/runtime/mangata-kusama/src/lib.rs
+++ b/runtime/mangata-kusama/src/lib.rs
@@ -140,7 +140,29 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	MangataMigrations,
 >;
+
+use frame_support::traits::OnRuntimeUpgrade;
+pub struct MangataMigrations;
+
+impl OnRuntimeUpgrade for MangataMigrations {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		pallet_bootstrap::migrations::v1::MigrateToV1::<Runtime>::on_runtime_upgrade()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		pallet_bootstrap::migrations::v1::MigrateToV1::<Runtime>::pre_upgrade();
+		Ok(())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		pallet_bootstrap::migrations::v1::MigrateToV1::<Runtime>::post_upgrade();
+		Ok(())
+	}
+}
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
 /// node's balance type.

--- a/runtime/mangata-kusama/src/lib.rs
+++ b/runtime/mangata-kusama/src/lib.rs
@@ -489,6 +489,15 @@ impl orml_tokens::Config for Runtime {
 	type DustRemovalWhitelist = DustRemovalWhitelist;
 }
 
+pub struct TestTokensFilter;
+impl Contains<TokenId> for TestTokensFilter {
+	fn contains(token_id: &TokenId) -> bool {
+		// we dont want to allow doing anything with dummy assets previously
+		// used for testing
+		*token_id == 2 || *token_id == 3
+	}
+}
+
 impl pallet_xyk::Config for Runtime {
 	type Event = Event;
 	type Currency = orml_tokens::MultiTokenCurrencyAdapter<Runtime>;
@@ -503,6 +512,7 @@ impl pallet_xyk::Config for Runtime {
 	type RewardsDistributionPeriod = frame_support::traits::ConstU32<10000>;
 	type VestingProvider = Vesting;
 	type DisallowedPools = Bootstrap;
+	type DisabledTokens = TestTokensFilter;
 	type WeightInfo = weights::pallet_xyk_weights::ModuleWeight<Runtime>;
 }
 

--- a/runtime/mangata-kusama/src/lib.rs
+++ b/runtime/mangata-kusama/src/lib.rs
@@ -507,8 +507,6 @@ impl pallet_xyk::Config for Runtime {
 
 impl pallet_bootstrap::Config for Runtime {
 	type Event = Event;
-	type MGATokenId = MgaTokenId;
-	type KSMTokenId = KsmTokenId;
 	type PoolCreateApi = Xyk;
 	type Currency = orml_tokens::MultiTokenCurrencyAdapter<Runtime>;
 	type VestingProvider = Vesting;

--- a/runtime/mangata-kusama/src/weights/pallet_bootstrap_weights.rs
+++ b/runtime/mangata-kusama/src/weights/pallet_bootstrap_weights.rs
@@ -58,6 +58,7 @@ pub trait WeightInfo {
 	fn provision() -> Weight;
 	fn provision_vested() -> Weight;
 	fn claim_rewards() -> Weight;
+	fn finalize() -> Weight;
 }
 
 /// Weights for pallet_bootstrap using the Mangata node and recommended hardware.
@@ -111,6 +112,11 @@ impl<T: frame_system::Config> pallet_bootstrap::WeightInfo for ModuleWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
 	}
+	fn finalize() -> Weight {
+		(157_076_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(13 as Weight))
+			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+	}
 }
 
 // For backwards compatibility and tests
@@ -131,6 +137,11 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
 	}
 	fn claim_rewards() -> Weight {
+		(157_076_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(13 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
+	}
+	fn finalize() -> Weight {
 		(157_076_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(13 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(6 as Weight))

--- a/runtime/mangata-rococo/Cargo.toml
+++ b/runtime/mangata-rococo/Cargo.toml
@@ -201,10 +201,6 @@ disable-execution = [
 	"frame-executive/disable-execution",
 ]
 
-enable-trading = [
-	"pallet-xyk/enable-trading"
-]
-
 runtime-benchmarks = [
 	"hex-literal",
 	"sp-runtime/runtime-benchmarks",

--- a/runtime/mangata-rococo/src/lib.rs
+++ b/runtime/mangata-rococo/src/lib.rs
@@ -140,7 +140,29 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	MangataMigrations,
 >;
+
+use frame_support::traits::OnRuntimeUpgrade;
+pub struct MangataMigrations;
+
+impl OnRuntimeUpgrade for MangataMigrations {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		pallet_bootstrap::migrations::v1::MigrateToV1::<Runtime>::on_runtime_upgrade()
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		pallet_bootstrap::migrations::v1::MigrateToV1::<Runtime>::pre_upgrade();
+		Ok(())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		pallet_bootstrap::migrations::v1::MigrateToV1::<Runtime>::post_upgrade();
+		Ok(())
+	}
+}
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
 /// node's balance type.
@@ -210,11 +232,11 @@ impl_opaque_keys! {
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("mangata-parachain"),
 	impl_name: create_runtime_str!("mangata-parachain"),
-	authoring_version: 4,
-	spec_version: 4,
+	authoring_version: 5,
+	spec_version: 5,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 4,
+	transaction_version: 5,
 	state_version: 0,
 };
 

--- a/runtime/mangata-rococo/src/lib.rs
+++ b/runtime/mangata-rococo/src/lib.rs
@@ -502,7 +502,7 @@ impl pallet_xyk::Config for Runtime {
 	type BuyAndBurnFeePercentage = frame_support::traits::ConstU128<5>;
 	type RewardsDistributionPeriod = frame_support::traits::ConstU32<10000>;
 	type VestingProvider = Vesting;
-	type DisallowedPools = Nothing;
+	type DisallowedPools = Bootstrap;
 	type WeightInfo = weights::pallet_xyk_weights::ModuleWeight<Runtime>;
 }
 
@@ -511,6 +511,7 @@ impl pallet_bootstrap::Config for Runtime {
 	type PoolCreateApi = Xyk;
 	type Currency = orml_tokens::MultiTokenCurrencyAdapter<Runtime>;
 	type VestingProvider = Vesting;
+	type TreasuryPalletId = TreasuryPalletId;
 	type WeightInfo = weights::pallet_bootstrap_weights::ModuleWeight<Runtime>;
 }
 

--- a/runtime/mangata-rococo/src/lib.rs
+++ b/runtime/mangata-rococo/src/lib.rs
@@ -507,8 +507,6 @@ impl pallet_xyk::Config for Runtime {
 
 impl pallet_bootstrap::Config for Runtime {
 	type Event = Event;
-	type MGATokenId = MgaTokenId;
-	type KSMTokenId = RocTokenId;
 	type PoolCreateApi = Xyk;
 	type Currency = orml_tokens::MultiTokenCurrencyAdapter<Runtime>;
 	type VestingProvider = Vesting;

--- a/runtime/mangata-rococo/src/lib.rs
+++ b/runtime/mangata-rococo/src/lib.rs
@@ -502,6 +502,7 @@ impl pallet_xyk::Config for Runtime {
 	type BuyAndBurnFeePercentage = frame_support::traits::ConstU128<5>;
 	type RewardsDistributionPeriod = frame_support::traits::ConstU32<10000>;
 	type VestingProvider = Vesting;
+	type DisallowedPools = Nothing;
 	type WeightInfo = weights::pallet_xyk_weights::ModuleWeight<Runtime>;
 }
 

--- a/runtime/mangata-rococo/src/lib.rs
+++ b/runtime/mangata-rococo/src/lib.rs
@@ -503,6 +503,7 @@ impl pallet_xyk::Config for Runtime {
 	type RewardsDistributionPeriod = frame_support::traits::ConstU32<10000>;
 	type VestingProvider = Vesting;
 	type DisallowedPools = Bootstrap;
+	type DisabledTokens = Nothing;
 	type WeightInfo = weights::pallet_xyk_weights::ModuleWeight<Runtime>;
 }
 

--- a/runtime/mangata-rococo/src/weights/pallet_bootstrap_weights.rs
+++ b/runtime/mangata-rococo/src/weights/pallet_bootstrap_weights.rs
@@ -58,6 +58,7 @@ pub trait WeightInfo {
 	fn provision() -> Weight;
 	fn provision_vested() -> Weight;
 	fn claim_rewards() -> Weight;
+	fn finalize() -> Weight;
 }
 
 /// Weights for pallet_bootstrap using the Mangata node and recommended hardware.
@@ -111,6 +112,11 @@ impl<T: frame_system::Config> pallet_bootstrap::WeightInfo for ModuleWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
 	}
+	fn finalize() -> Weight {
+		(157_076_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(13 as Weight))
+			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+	}
 }
 
 // For backwards compatibility and tests
@@ -131,6 +137,11 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
 	}
 	fn claim_rewards() -> Weight {
+		(157_076_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(13 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
+	}
+	fn finalize() -> Weight {
 		(157_076_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(13 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(6 as Weight))


### PR DESCRIPTION
- allow claiming rewards for specific user
- finalize draft
- provide finalize() extrinsics that purges all storages
- store all unique provision account
- successfully execute Bootstrap::claim_rewards even if user liquidity token share == 0
- rename extrinsic start_ido -> schedule_bootstrap
- dedicated storage for bootstrap token pair
- use configurable token id
- remove KSMTokenId & MGATokenId constants
- remove hardcoded token names in bootstrap code
- support for blacklisting pools
- use Bootstrap as Disallowed pool provider
- transfer remaining liquidity tokens to treasury
- archive previous bootstrap info
- perform storage write only once per state change
- provide limit parameter that allows for itertive finalization of bootstrap
- get rid of enable-trading feature
