### PR TITLE
Update ci.yml to get docker logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,6 @@ jobs:
         if: failure()
         uses: jwalton/gh-docker-logs@v1
         with:
-          images: 'mangata,polkadot'
           dest: './logs'
 
       - name: Tar logs


### PR DESCRIPTION
looks like somebody forgot adapting this when updating how parachain runs