### PR TITLE
Fast runtime feature for rococo & kusama

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,11 @@ on:
         description: Version to be assigned to the built image
         required: true
         type: string
+      branch:
+        default: ci
+        description: Branch that given job relates to, that value will be used to tag docker image mangatasolutions/mangata-node:<BRANCH_NAME>
+        required: true
+        type: string
       builder_image:
         default: mangatasolutions/node-builder:multi-nightly-2022-11-21
         description: Docker image used for Rust builds
@@ -49,18 +54,46 @@ jobs:
       
       - name: Compile mangata-node code
         run: cargo build --release --no-default-features --features=mangata-rococo,mangata-kusama
+
+      - name: Rename wasms
+        run: |
+          cp target/release/wbuild/mangata-kusama-runtime/mangata_kusama_runtime.compact.compressed.wasm ./mangata_kusama_runtime-${{ inputs.version }}.compact.compressed.wasm
+          cp target/release/wbuild/mangata-rococo-runtime/mangata_rococo_runtime.compact.compressed.wasm ./mangata_rococo_runtime-${{ inputs.version }}.compact.compressed.wasm
       
       - name: Build and push Docker image
         run: |
           docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
           docker build -f devops/dockerfiles/node-new/Dockerfile \
-          -t mangatasolutions/mangata-node:${{ inputs.version }} .
+          -t mangatasolutions/mangata-node:${{ inputs.version }} \
+          -t mangatasolutions/mangata-node:${{ inputs.branch }} .
           docker push mangatasolutions/mangata-node:${{ inputs.version }}
+          docker push mangatasolutions/mangata-node:${{ inputs.branch }}
+
+      - name: Compile mangata-node code with fast runtime
+        run: cargo build --release --no-default-features --features=mangata-rococo,mangata-kusama,fast-runtime
+
+      - name: Rename wasms with fast runtime
+        run: |
+          cp target/release/wbuild/mangata-kusama-runtime/mangata_kusama_runtime.compact.compressed.wasm ./mangata_kusama_runtime-${{ inputs.version }}-fast.compact.compressed.wasm
+          cp target/release/wbuild/mangata-rococo-runtime/mangata_rococo_runtime.compact.compressed.wasm ./mangata_rococo_runtime-${{ inputs.version }}-fast.compact.compressed.wasm
       
+      - name: Build and push Docker image with fast runtime
+        run: |
+          docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+          docker build -f devops/dockerfiles/node-new/Dockerfile \
+          -t mangatasolutions/mangata-node:${{ inputs.version }}-fast \
+          -t mangatasolutions/mangata-node:${{ inputs.branch }}-fast .
+          docker push mangatasolutions/mangata-node:${{ inputs.version }}-fast
+          docker push mangatasolutions/mangata-node:${{ inputs.branch }}-fast
+
       - uses: actions/upload-artifact@v3
         with:
           name: wasms-${{ inputs.version }}
-          path: target/release/wbuild/*/mangata_*_runtime.compact.compressed.wasm
+          path: |
+            ./mangata_kusama_runtime-${{ inputs.version }}.compact.compressed.wasm
+            ./mangata_rococo_runtime-${{ inputs.version }}.compact.compressed.wasm
+            ./mangata_kusama_runtime-${{ inputs.version }}-fast.compact.compressed.wasm
+            ./mangata_rococo_runtime-${{ inputs.version }}-fast.compact.compressed.wasm
       
       - name: Fix permissions on self-hosted runner
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ on:
         default: false
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   deployments: write
   checks: write
@@ -48,11 +48,17 @@ jobs:
     if: github.event.action != 'unlabeled' && github.event.action != 'closed'
     runs-on: ubuntu-latest
     outputs:
-      GLOBAL_VERSION: ${{ steps.set_ver.outputs.GLOBAL_VERSION }}
+      GLOBAL_VERSION: ${{ steps.set_vars.outputs.GLOBAL_VERSION }}
+      GIT_BRANCH: ${{ steps.set_vars.outputs.GIT_BRANCH }}
     steps:
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v6
       - name: Set global version
-        id: set_ver
-        run: echo "GLOBAL_VERSION=${{ github.sha }}" >> $GITHUB_OUTPUT
+        id: set_vars
+        run: |
+          echo "GLOBAL_VERSION=${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "GIT_BRANCH=${{ steps.branch-name.outputs.current_branch }}" | sed "s@/@-@g" >> $GITHUB_OUTPUT
 
   build-and-test:
     if: ${{ github.event.inputs.skipBuild != 'true' }}
@@ -62,6 +68,7 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.init.outputs.GLOBAL_VERSION }}
+      branch: ${{ needs.init.outputs.GIT_BRANCH }}
 
   deploy-fungible:
     name: Deploy fungible environment

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -32,6 +32,7 @@ mangata-rococo = [
 ]
 #disable-execution = ['mangata-kusama-runtime/disable-execution']
 runtime-benchmarks = ["mangata-kusama-runtime/runtime-benchmarks", "polkadot-cli/runtime-benchmarks"]
+fast-runtime = ["mangata-kusama-runtime/fast-runtime", "mangata-kusama-runtime/fast-runtime"] 
 try-runtime = ["mangata-kusama-runtime/try-runtime", "mangata-rococo-runtime/try-runtime"]
 
 [dependencies]

--- a/runtime/mangata-kusama/Cargo.toml
+++ b/runtime/mangata-kusama/Cargo.toml
@@ -219,9 +219,7 @@ try-runtime = [
 	"pallet-utility/try-runtime",
 ]
 
-#disable-execution = [
-#	"frame-executive/disable-execution",
-#]
+fast-runtime = []
 
 runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",

--- a/runtime/mangata-kusama/src/lib.rs
+++ b/runtime/mangata-kusama/src/lib.rs
@@ -500,6 +500,8 @@ impl AssetMetadataMutationTrait for AssetMetadataMutation {
 	}
 }
 
+type SessionLenghtOf<T> = <T as parachain_staking::Config>::BlocksPerRound;
+
 impl pallet_xyk::Config for Runtime {
 	type Event = Event;
 	type ActivationReservesProvider = MultiPurposeLiquidity;
@@ -512,7 +514,7 @@ impl pallet_xyk::Config for Runtime {
 	type PoolFeePercentage = frame_support::traits::ConstU128<20>;
 	type TreasuryFeePercentage = frame_support::traits::ConstU128<5>;
 	type BuyAndBurnFeePercentage = frame_support::traits::ConstU128<5>;
-	type RewardsDistributionPeriod = frame_support::traits::ConstU32<1200>;
+	type RewardsDistributionPeriod = SessionLenghtOf<Runtime>;
 	type VestingProvider = Vesting;
 	type DisallowedPools = Bootstrap;
 	type DisabledTokens = TestTokensFilter;
@@ -827,9 +829,19 @@ impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type WeightInfo = weights::pallet_collective_weights::ModuleWeight<Runtime>;
 }
 
+#[cfg(feature = "fast-runtime")]
 parameter_types! {
-	/// Default BlocksPerRound is every 4 hours (1200 * 12 second block times)
+	/// Default SessionLenght is every 2 minutes (10 * 12 second block times)
+	pub const BlocksPerRound: u32 = 2 * MINUTES;
+}
+
+#[cfg(not(feature = "fast-runtime"))]
+parameter_types! {
+	/// Default SessionLenght is every 4 hours (1200 * 12 second block times)
 	pub const BlocksPerRound: u32 = 4 * HOURS;
+}
+
+parameter_types! {
 	/// Collator candidate exit delay (number of rounds)
 	pub const LeaveCandidatesDelay: u32 = 2;
 	/// Collator candidate bond increases/decreases delay (number of rounds)

--- a/runtime/mangata-rococo/Cargo.toml
+++ b/runtime/mangata-rococo/Cargo.toml
@@ -220,9 +220,7 @@ try-runtime = [
 	"pallet-utility/try-runtime",
 ]
 
-#disable-execution = [
-#	"frame-executive/disable-execution",
-#]
+fast-runtime = []
 
 runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",

--- a/runtime/mangata-rococo/src/lib.rs
+++ b/runtime/mangata-rococo/src/lib.rs
@@ -491,6 +491,8 @@ impl AssetMetadataMutationTrait for AssetMetadataMutation {
 	}
 }
 
+type SessionLenghtOf<T> = <T as parachain_staking::Config>::BlocksPerRound;
+
 impl pallet_xyk::Config for Runtime {
 	type Event = Event;
 	type ActivationReservesProvider = MultiPurposeLiquidity;
@@ -503,7 +505,7 @@ impl pallet_xyk::Config for Runtime {
 	type PoolFeePercentage = frame_support::traits::ConstU128<20>;
 	type TreasuryFeePercentage = frame_support::traits::ConstU128<5>;
 	type BuyAndBurnFeePercentage = frame_support::traits::ConstU128<5>;
-	type RewardsDistributionPeriod = frame_support::traits::ConstU32<1200>;
+	type RewardsDistributionPeriod = SessionLenghtOf<Runtime>;
 	type VestingProvider = Vesting;
 	type DisallowedPools = Bootstrap;
 	type DisabledTokens = Nothing;
@@ -818,9 +820,19 @@ impl pallet_collective::Config<CouncilCollective> for Runtime {
 	type WeightInfo = weights::pallet_collective_weights::ModuleWeight<Runtime>;
 }
 
+#[cfg(feature = "fast-runtime")]
 parameter_types! {
-	/// Default BlocksPerRound is every 4 hours (1200 * 12 second block times)
+	/// Default SessionLenght is every 2 minutes (10 * 12 second block times)
+	pub const BlocksPerRound: u32 = 2 * MINUTES;
+}
+
+#[cfg(not(feature = "fast-runtime"))]
+parameter_types! {
+	/// Default SessionLenght is every 4 hours (1200 * 12 second block times)
 	pub const BlocksPerRound: u32 = 4 * HOURS;
+}
+
+parameter_types! {
 	/// Collator candidate exit delay (number of rounds)
 	pub const LeaveCandidatesDelay: u32 = 2;
 	/// Collator candidate bond increases/decreases delay (number of rounds)


### PR DESCRIPTION
- fetch rewards distribution period directly from SessionManager
- implement fast-runtime feature for mangat & rococo runtimes
- introduce fast-runtime feature to manifests
- publish images with branch name & fast runtime


That pr enables publishing multiple docker images
- `mangatasolutions/mangata-node:<GIT_SHA>` - docker image tagged with git commit
- `mangatasolutions/mangata-node:<GIT_SHA>-fast` - docker image buile with `fast-runtime` feature tagged with git commit 
- `mangatasolutions/mangata-node:<GIT_BRANCH_NAME>` - docker image tagged with branch name :tada: 
- `mangatasolutions/mangata-node:<GIT_BRANCH_NAME>-fast` - docker image build with `fast-runtime` tagged with branch name :tada: 

** note that images tagged with branch name replaces `/` with `-` because of docker tag naming limitation ** as a result images built for this particular branch `feature/fast-runtime` are
- `mangatasolutions/mangata-node:feature-fast-runtime`
- `mangatasolutions/mangata-node:feature-fast-runtime-fast`

All the wasm files are stored as artifacts and named properly so they will not overwrite previously unpacked wasms
```
unzip wasms-cf4b1782d834df257f1daf1029b7d995f5db008e.zip
Archive:  wasms-cf4b1782d834df257f1daf1029b7d995f5db008e.zip
  inflating: mangata_kusama_runtime-cf4b1782d834df257f1daf1029b7d995f5db008e-fast.compact.compressed.wasm  
  inflating: mangata_kusama_runtime-cf4b1782d834df257f1daf1029b7d995f5db008e.compact.compressed.wasm  
  inflating: mangata_rococo_runtime-cf4b1782d834df257f1daf1029b7d995f5db008e-fast.compact.compressed.wasm  
  inflating: mangata_rococo_runtime-cf4b1782d834df257f1daf1029b7d995f5db008e.compact.compressed.wasm
```

