### PR TITLE
fix parachain-staking docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6753,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "parachain-staking"
 version = "3.0.0"
-source = "git+https://github.com/mangata-finance//moonbeam?branch=mangata-dev#b84fc1beef903f585ee5337e9bb20b89a46e745b"
+source = "git+https://github.com/mangata-finance//moonbeam?branch=mangata-dev#a702e39e5ebd51bf10d02ce22990f3e68eda50f6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",


### PR DESCRIPTION
diffs in parachain-staking

```
diff --git a/Cargo.lock b/Cargo.lock
index d0f93bf46..2601d0ce8 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,6 +3910,26 @@ dependencies = [
  "synstructure",
 ]
 
+[[patch.unused]]
+name = "orml-unknown-tokens"
+version = "0.4.1-dev"
+source = "git+https://github.com/mangata-finance//open-runtime-module-library?branch=mangata-dev#1d6fbd1374eabcd016ada4253d81c316b1084228"
+
+[[patch.unused]]
+name = "orml-xcm"
+version = "0.4.1-dev"
+source = "git+https://github.com/mangata-finance//open-runtime-module-library?branch=mangata-dev#1d6fbd1374eabcd016ada4253d81c316b1084228"
+
+[[patch.unused]]
+name = "orml-xcm-support"
+version = "0.4.1-dev"
+source = "git+https://github.com/mangata-finance//open-runtime-module-library?branch=mangata-dev#1d6fbd1374eabcd016ada4253d81c316b1084228"
+
+[[patch.unused]]
+name = "orml-xtokens"
+version = "0.4.1-dev"
+source = "git+https://github.com/mangata-finance//open-runtime-module-library?branch=mangata-dev#1d6fbd1374eabcd016ada4253d81c316b1084228"
+
 [[patch.unused]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
@@ -5574,23 +5594,3 @@ source = "git+https://github.com/mangata-finance//substrate?branch=mangata-dev#c
 name = "try-runtime-cli"
 version = "0.10.0-dev"
 source = "git+https://github.com/mangata-finance//substrate?branch=mangata-dev#cbe2bfab50a8f36e35877bd80ff9cbe2fa3ef694"
-
-[[patch.unused]]
-name = "orml-unknown-tokens"
-version = "0.4.1-dev"
-source = "git+https://github.com/mangata-finance//open-runtime-module-library?branch=mangata-dev#1d6fbd1374eabcd016ada4253d81c316b1084228"
-
-[[patch.unused]]
-name = "orml-xcm"
-version = "0.4.1-dev"
-source = "git+https://github.com/mangata-finance//open-runtime-module-library?branch=mangata-dev#1d6fbd1374eabcd016ada4253d81c316b1084228"
-
-[[patch.unused]]
-name = "orml-xcm-support"
-version = "0.4.1-dev"
-source = "git+https://github.com/mangata-finance//open-runtime-module-library?branch=mangata-dev#1d6fbd1374eabcd016ada4253d81c316b1084228"
-
-[[patch.unused]]
-name = "orml-xtokens"
-version = "0.4.1-dev"
-source = "git+https://github.com/mangata-finance//open-runtime-module-library?branch=mangata-dev#1d6fbd1374eabcd016ada4253d81c316b1084228"
diff --git a/pallets/parachain-staking/src/lib.rs b/pallets/parachain-staking/src/lib.rs
index 400d9eaed..aa403d5a3 100644
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -68,10 +68,10 @@
 //!              |                       |                      |         
 //!              |                       |                      |         
 //!              |                       |                      |         
-//!      ####################  ####################  ####################
-//!      #  Candidate B     #  #  Candidate C     #  #  Candidate D     #
-//!      # token: MGX:TUR   #  # token: MGX:IMBU  #  # token: MGX:MOVR  #
-//!      ####################  ####################  ####################
+//!      --------------------  --------------------  --------------------
+//!      |  Candidate B     |  |  Candidate C     |  |  Candidate D     |
+//!      | token: MGX:TUR   |  | token: MGX:IMBU  |  | token: MGX:MOVR  |
+//!      --------------------  --------------------  --------------------
 //! ```
 //!
 //! If candidate decides to aggregate under Aggregator it cannot be chosen to be collator(the
@@ -85,8 +85,8 @@
 //!```
 //!
 //! Extrinsics:
-//! - `[Pallet::aggregator_update_metadata]` - enable/disable candidates for aggregation
-//! - `[Pallet::update_candidate_aggregator]` - assign aggregator for candidate
+//! - [`Pallet::aggregator_update_metadata`] - enable/disable candidates for aggregation
+//! - [`Pallet::update_candidate_aggregator`] - assign aggregator for candidate
 //!
 //! Storage entries:
 //! - [`CandidateAggregator`]

```