### PR TITLE
Update reusable-e2e-tests.yml

### DIFF
--- a/.github/workflows/reusable-e2e-tests.yml
+++ b/.github/workflows/reusable-e2e-tests.yml
@@ -175,7 +175,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18.16.1'
           cache: 'yarn'
           cache-dependency-path: '**/yarn.lock'
 


### PR DESCRIPTION
now sdk validates node version. bumped to 18.16.1