### PR TITLE
Post v0.31.0 alignment

### DIFF
--- a/.github/workflows/reusable-build-and-test.yml
+++ b/.github/workflows/reusable-build-and-test.yml
@@ -249,9 +249,8 @@ jobs:
             ~/.cache/sccache
           key: cargo-try-runtime-${{ inputs.cache_version }}-${{ hashFiles('Cargo.lock') }}
 
-      # NOTE: Rococo has been already upgraded so lets disable rococo try-runtime
-      # - name: Run try-runtime Rococo testnet
-      #   run: cargo run --release --features=try-runtime,mangata-rococo try-runtime --chain=rococo --runtime=target/release/wbuild/mangata-rococo-runtime/mangata_rococo_runtime.wasm on-runtime-upgrade live --uri wss://collator-01-ws-rococo.mangata.online:443
+      - name: Run try-runtime Rococo testnet
+        run: cargo run --release --features=try-runtime,mangata-rococo try-runtime --chain=rococo --runtime=target/release/wbuild/mangata-rococo-runtime/mangata_rococo_runtime.wasm on-runtime-upgrade live --uri wss://collator-01-ws-rococo.mangata.online:443
 
       - name: Run try-runtime Kusama Mainnet
         run: cargo run --release --features=try-runtime try-runtime --chain=kusama --runtime=target/release/wbuild/mangata-kusama-runtime/mangata_kusama_runtime.wasm on-runtime-upgrade live --uri wss://kusama-rpc.mangata.online:443

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6287,7 +6287,7 @@ dependencies = [
 [[package]]
 name = "pallet-crowdloan-rewards"
 version = "0.6.0"
-source = "git+https://github.com/mangata-finance//crowdloan-rewards?branch=mangata-dev#93f22908087bf475bf1021bc9c3337fefd00fb39"
+source = "git+https://github.com/mangata-finance//crowdloan-rewards?branch=mangata-dev#ee55b9650c36f63063357a83e54d0f8b881b4c93"
 dependencies = [
  "ed25519-dalek",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6287,7 +6287,7 @@ dependencies = [
 [[package]]
 name = "pallet-crowdloan-rewards"
 version = "0.6.0"
-source = "git+https://github.com/mangata-finance//crowdloan-rewards?branch=mangata-dev#ee55b9650c36f63063357a83e54d0f8b881b4c93"
+source = "git+https://github.com/mangata-finance//crowdloan-rewards?branch=mangata-dev#8a59680579ca8377e79523a2008244881dca5569"
 dependencies = [
  "ed25519-dalek",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6287,7 +6287,7 @@ dependencies = [
 [[package]]
 name = "pallet-crowdloan-rewards"
 version = "0.6.0"
-source = "git+https://github.com/mangata-finance//crowdloan-rewards?branch=mangata-dev#8a59680579ca8377e79523a2008244881dca5569"
+source = "git+https://github.com/mangata-finance//crowdloan-rewards?branch=mangata-dev#6d7f6cc5c8c5122e031e88062ffc48d7c6bc8f3e"
 dependencies = [
  "ed25519-dalek",
  "frame-benchmarking",

--- a/runtime/mangata-kusama/src/lib.rs
+++ b/runtime/mangata-kusama/src/lib.rs
@@ -117,10 +117,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("mangata-parachain"),
 	impl_name: create_runtime_str!("mangata-parachain"),
 	authoring_version: 15,
-	spec_version: 003100,
+	spec_version: 003200,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 003100,
+	transaction_version: 003200,
 	state_version: 0,
 };
 

--- a/runtime/mangata-rococo/src/lib.rs
+++ b/runtime/mangata-rococo/src/lib.rs
@@ -117,10 +117,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("mangata-parachain"),
 
 	authoring_version: 14,
-	spec_version: 003100,
+	spec_version: 003200,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 003100,
+	transaction_version: 003200,
 	state_version: 0,
 };
 


### PR DESCRIPTION
- CI: Fix production release workflow (#622)
- disable crowdloan migration
- Revert "temporary disable try-runtime for rococo"
