### PR TITLE
chainspec config that sets intial collators to also have sequencers rights

### DIFF
--- a/node/src/chain_spec/mangata_rococo.rs
+++ b/node/src/chain_spec/mangata_rococo.rs
@@ -195,6 +195,7 @@ pub fn mangata_rococo_prod_config() -> ChainSpec {
 					),
 				],
 				parachains::mangata::ID.into(),
+				false,
 			)
 		},
 		Vec::new(),
@@ -212,7 +213,7 @@ pub fn mangata_rococo_prod_config() -> ChainSpec {
 	)
 }
 
-pub fn mangata_rococo_local_config() -> ChainSpec {
+pub fn mangata_rococo_local_config(initial_collators_as_sequencers: bool) -> ChainSpec {
 	// Give your base currency a unit name and decimal places
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "MGRL".into());
@@ -397,6 +398,7 @@ pub fn mangata_rococo_local_config() -> ChainSpec {
 					),
 				],
 				parachains::mangata::ID.into(),
+				initial_collators_as_sequencers,
 			)
 		},
 		// Bootnodes
@@ -425,6 +427,7 @@ pub(crate) fn mangata_genesis(
 	staking_accounts: Vec<(AccountId, u32, u128, u32, u128, u32, u128)>,
 	register_assets: Vec<(u32, AssetMetadataOf)>,
 	id: ParaId,
+	initial_collators_as_sequencers: bool,
 ) -> mangata_rococo_runtime::RuntimeGenesisConfig {
 	mangata_rococo_runtime::RuntimeGenesisConfig {
 		system: mangata_rococo_runtime::SystemConfig {
@@ -547,7 +550,11 @@ pub(crate) fn mangata_genesis(
 		},
 		vesting: Default::default(),
 		rolldown: mangata_rococo_runtime::RolldownConfig {
-			sequencers: initial_authorities.iter().map(|(acc, _)| acc.clone()).collect(),
+			sequencers: if initial_collators_as_sequencers {
+				initial_authorities.iter().map(|(acc, _)| acc.clone()).collect()
+			} else {
+				Default::default()
+			},
 		},
 	}
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -90,7 +90,9 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 	Ok(match id {
 		// - Rococo based
 		"mangata-rococo-local" =>
-			Box::new(chain_spec::mangata_rococo::mangata_rococo_local_config()),
+			Box::new(chain_spec::mangata_rococo::mangata_rococo_local_config(false)),
+		"mangata-rococo-local-seq" =>
+			Box::new(chain_spec::mangata_rococo::mangata_rococo_local_config(true)),
 		"mangata-rococo" => Box::new(chain_spec::mangata_rococo::mangata_rococo_prod_config()),
 		// - Kusama based
 		"mangata-kusama-local" =>
@@ -100,7 +102,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		// -- Fallback (generic chainspec)
 		"" => {
 			log::warn!("No ChainSpec.id specified, so using default one, based on rococo-parachain runtime");
-			Box::new(chain_spec::mangata_rococo::mangata_rococo_local_config())
+			Box::new(chain_spec::mangata_rococo::mangata_rococo_local_config(false))
 		},
 
 		// -- Loading a specific spec from disk
@@ -646,6 +648,7 @@ mod tests {
 					vec![],
 					vec![],
 					1000.into(),
+					false,
 				)
 			},
 			Vec::new(),


### PR DESCRIPTION
`mangata-rococo-local-seq` Can be used to simplify initial setup for L1 <--> L2 communication