### PR TITLE
Account for read/cancel rights locked in dispute period and cancel resolutions

### DIFF
--- a/pallets/rolldown/src/lib.rs
+++ b/pallets/rolldown/src/lib.rs
@@ -527,7 +527,7 @@ impl<T: Config> Pallet<T> {
 			if T::SequencerStakingProvider::is_active_sequencer(l1, sequencer) {
 				SequencersRights::<T>::mutate(l1, |sequencers| {
 					if let Some(rights) = sequencers.get_mut(sequencer) {
-						rights.read_rights = 1;
+						rights.read_rights.saturating_accrue(T::RightsMultiplier::get());
 					}
 				});
 			}
@@ -547,7 +547,6 @@ impl<T: Config> Pallet<T> {
 		if request.id() <= LastProcessedRequestOnL2::<T>::get(l1) {
 			return
 		}
-
 		let id = L2OriginRequestId::<T>::get(l1);
 		L2OriginRequestId::<T>::mutate(l1, |request_id| {
 			request_id.saturating_inc();


### PR DESCRIPTION
- **reproduce scenarios where delayed execution of request can be exploitet to get extra rights**
- **account for pending read/cancel rights locked in dispute_period and cancel resolutions**

logs from reproduced test cases
```
running 3 tests
test tests::consider_awaiting_cancel_resolutions_and_cancel_disputes_when_assigning_initial_read_rights_to_sequencer ... FAILED
test tests::consider_awaiting_cancel_resolutions_and_cancel_disputes_when_assigning_initial_cancel_rights_to_sequencer ... FAILED
test tests::consider_awaiting_l1_READ_update_in_dispute_period_when_assigning_initial_read_rights_to_sequencer ... FAILED

failures:

---- tests::consider_awaiting_cancel_resolutions_and_cancel_disputes_when_assigning_initial_read_rights_to_sequencer stdout ----
thread 'tests::consider_awaiting_cancel_resolutions_and_cancel_disputes_when_assigning_initial_read_rights_to_sequencer' panicked at 'assertion failed: `(left == right)`
  left: `SequencerRights { read_rights: 2, cancel_rights: 2 }`,
 right: `SequencerRights { read_rights: 1, cancel_rights: 2 }`', pallets/rolldown/src/tests.rs:2061:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::consider_awaiting_cancel_resolutions_and_cancel_disputes_when_assigning_initial_cancel_rights_to_sequencer stdout ----
thread 'tests::consider_awaiting_cancel_resolutions_and_cancel_disputes_when_assigning_initial_cancel_rights_to_sequencer' panicked at 'assertion failed: `(left == right)`
  left: `SequencerRights { read_rights: 1, cancel_rights: 4 }`,
 right: `SequencerRights { read_rights: 1, cancel_rights: 2 }`', pallets/rolldown/src/tests.rs:1906:13

---- tests::consider_awaiting_l1_READ_update_in_dispute_period_when_assigning_initial_read_rights_to_sequencer stdout ----
thread 'tests::consider_awaiting_l1_READ_update_in_dispute_period_when_assigning_initial_read_rights_to_sequencer' panicked at 'assertion failed: `(left == right)`
  left: `SequencerRights { read_rights: 2, cancel_rights: 2 }`,
 right: `SequencerRights { read_rights: 1, cancel_rights: 2 }`', pallets/rolldown/src/tests.rs:1980:13


failures:
    tests::consider_awaiting_cancel_resolutions_and_cancel_disputes_when_assigning_initial_cancel_rights_to_sequencer
    tests::consider_awaiting_cancel_resolutions_and_cancel_disputes_when_assigning_initial_read_rights_to_sequencer
    tests::consider_awaiting_l1_READ_update_in_dispute_period_when_assigning_initial_read_rights_to_sequencer

test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 45 filtered out; finished in 0.04s

```

