### PR TITLE
[MGX-1366][MGX-1370] Manual Batches & Maintanance Mode alignments

### DIFF
--- a/pallets/rolldown/src/lib.rs
+++ b/pallets/rolldown/src/lib.rs
@@ -115,7 +115,7 @@ pub mod pallet {
 			let batch_period: BlockNumberFor<T> = Self::automatic_batch_period().saturated_into();
 
 			if T::MaintenanceStatusProvider::is_maintenance() {
-				return T::DbWeight::get().reads_writes(10, 20);
+				return T::DbWeight::get().reads_writes(10, 20)
 			}
 
 			for (chain, next_id) in L2OriginRequestId::<T>::get().iter() {
@@ -664,7 +664,6 @@ pub mod pallet {
 				Error::<T>::BlockedByMaintenanceMode
 			);
 
-
 			let asignee = if let Some(sequencer) = sequencer_account {
 				ensure!(
 					T::SequencerStakingProvider::is_active_sequencer_alias(
@@ -698,13 +697,19 @@ pub mod pallet {
 			let range_start = last_request_id.saturating_add(1u128);
 
 			ensure!(
-				L2Requests::<T>::contains_key(chain, RequestId{origin: Origin::L2, id: range_start} ),
+				L2Requests::<T>::contains_key(
+					chain,
+					RequestId { origin: Origin::L2, id: range_start }
+				),
 				Error::<T>::EmptyBatch
 			);
 			let range_end = Self::get_latest_l2_request_id(chain).ok_or(Error::<T>::EmptyBatch)?;
 			ensure!(range_end >= range_start, Error::<T>::InvalidRange);
 
-			L2RequestsBatch::<T>::insert((chain, batch_id), (now, (range_start, range_end), asignee.clone()));
+			L2RequestsBatch::<T>::insert(
+				(chain, batch_id),
+				(now, (range_start, range_end), asignee.clone()),
+			);
 			L2RequestsBatchLast::<T>::mutate(|batches| {
 				batches.insert(chain.clone(), (now, batch_id, (range_start, range_end)));
 			});
@@ -1305,10 +1310,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn get_latest_l2_request_id(chain: ChainIdOf<T>) -> Option<u128> {
-		L2OriginRequestId::<T>::get()
-			.get(&chain)
-			.cloned()
-			.map(|v| v.saturating_sub(1))
+		L2OriginRequestId::<T>::get().get(&chain).cloned().map(|v| v.saturating_sub(1))
 	}
 
 	pub fn verify_merkle_proof_for_tx(

--- a/pallets/rolldown/src/lib.rs
+++ b/pallets/rolldown/src/lib.rs
@@ -389,6 +389,7 @@ pub mod pallet {
 		NonExistingRequestId,
 		UnknownAliasAccount,
 		FailedDepositDoesExists,
+		EmptyBatch,
 	}
 
 	#[pallet::config]
@@ -649,7 +650,6 @@ pub mod pallet {
 		pub fn create_batch(
 			origin: OriginFor<T>,
 			chain: T::ChainId,
-			range: (u128, u128),
 			sequencer_account: Option<T::AccountId>,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
@@ -678,34 +678,33 @@ pub mod pallet {
 				)?;
 			}
 
-			ensure!(range.0 <= range.1, Error::<T>::InvalidRange);
-			ensure!(range.0 > 0, Error::<T>::InvalidRange);
-
-			ensure!(
-				range.1 < Self::get_l2_origin_updates_counter(chain),
-				Error::<T>::NonExistingRequestId
-			);
-
 			let (last_batch_id, last_request_id) = L2RequestsBatchLast::<T>::get()
 				.get(&chain)
 				.cloned()
 				.map(|(_block_number, batch_id, range)| (batch_id, range.1))
 				.unwrap_or_default();
 
-			ensure!(range.0 <= last_request_id + 1, Error::<T>::InvalidRange);
-
 			let batch_id = last_batch_id.saturating_add(1u128);
+			let range_start = last_request_id.saturating_add(1u128);
 
-			L2RequestsBatch::<T>::insert((chain, batch_id), (now, range, asignee.clone()));
+			ensure!(
+				L2Requests::<T>::contains_key(chain, RequestId{origin: Origin::L2, id: range_start} ),
+				Error::<T>::EmptyBatch
+			);
+			let range_end = Self::get_latest_l2_request_id(chain).ok_or(Error::<T>::EmptyBatch)?;
+			ensure!(range_end >= range_start, Error::<T>::InvalidRange);
+
+			L2RequestsBatch::<T>::insert((chain, batch_id), (now, (range_start, range_end), asignee.clone()));
 			L2RequestsBatchLast::<T>::mutate(|batches| {
-				batches.insert(chain.clone(), (now, batch_id, range));
+				batches.insert(chain.clone(), (now, batch_id, (range_start, range_end)));
 			});
+
 			Pallet::<T>::deposit_event(Event::TxBatchCreated {
 				chain,
 				source: BatchSource::Manual,
 				assignee: asignee.clone(),
 				batch_id,
-				range,
+				range: (range_start, range_end),
 			});
 
 			Ok(().into())
@@ -1291,8 +1290,15 @@ impl<T: Config> Pallet<T> {
 		})
 	}
 
-	pub(crate) fn get_l2_origin_updates_counter(chain: ChainIdOf<T>) -> u128 {
+	pub(crate) fn get_next_l2_request_id(chain: ChainIdOf<T>) -> u128 {
 		L2OriginRequestId::<T>::get().get(&chain).cloned().unwrap_or(1u128)
+	}
+
+	fn get_latest_l2_request_id(chain: ChainIdOf<T>) -> Option<u128> {
+		L2OriginRequestId::<T>::get()
+			.get(&chain)
+			.cloned()
+			.map(|v| v.saturating_sub(1))
 	}
 
 	pub fn verify_merkle_proof_for_tx(

--- a/pallets/rolldown/src/tests.rs
+++ b/pallets/rolldown/src/tests.rs
@@ -425,7 +425,7 @@ fn test_malicious_sequencer_is_slashed_when_honest_sequencer_cancels_malicious_r
 				.with_requests(vec![L1UpdateRequest::Deposit(Default::default())])
 				.build();
 
-			let l2_request_id = Rolldown::get_l2_origin_updates_counter(Chain::Ethereum);
+			let l2_request_id = Rolldown::get_next_l2_request_id(Chain::Ethereum);
 			let cancel_resolution = L1UpdateBuilder::default()
 				.with_requests(vec![L1UpdateRequest::CancelResolution(
 					messages::CancelResolution {
@@ -503,7 +503,7 @@ fn test_malicious_canceler_is_slashed_when_honest_read_is_canceled() {
 				.with_requests(vec![L1UpdateRequest::Deposit(Default::default())])
 				.build();
 
-			let l2_request_id = Rolldown::get_l2_origin_updates_counter(Chain::Ethereum);
+			let l2_request_id = Rolldown::get_next_l2_request_id(Chain::Ethereum);
 			let cancel_resolution = L1UpdateBuilder::default()
 				.with_requests(vec![L1UpdateRequest::CancelResolution(
 					messages::CancelResolution {
@@ -576,7 +576,7 @@ fn test_trigger_maintanance_mode_when_processing_cancel_resolution_triggers_an_e
 
 			forward_to_block::<Test>(10);
 
-			let l2_request_id = Rolldown::get_l2_origin_updates_counter(Chain::Ethereum);
+			let l2_request_id = Rolldown::get_next_l2_request_id(Chain::Ethereum);
 			let cancel_resolution = L1UpdateBuilder::default()
 				.with_requests(vec![L1UpdateRequest::CancelResolution(
 					messages::CancelResolution {
@@ -630,7 +630,7 @@ fn test_cancel_removes_cancel_right() {
 			let slash_sequencer_mock = MockSequencerStakingProviderApi::slash_sequencer_context();
 			slash_sequencer_mock.expect().return_const(Ok(().into()));
 
-			let l2_request_id = Rolldown::get_l2_origin_updates_counter(Chain::Ethereum);
+			let l2_request_id = Rolldown::get_next_l2_request_id(Chain::Ethereum);
 			let deposit_update = L1UpdateBuilder::default()
 				.with_requests(vec![L1UpdateRequest::Deposit(messages::Deposit::default())])
 				.build();
@@ -1066,7 +1066,7 @@ fn test_withdraw() {
 					.0,
 				L2Request::Withdrawal(withdrawal_update)
 			);
-			assert_eq!(Rolldown::get_l2_origin_updates_counter(Chain::Ethereum), 2);
+			assert_eq!(Rolldown::get_next_l2_request_id(Chain::Ethereum), 2);
 		});
 }
 
@@ -1253,7 +1253,7 @@ fn test_cancel_updates_awaiting_cancel_resolution() {
 				.unwrap();
 			assert!(PendingSequencerUpdates::<Test>::contains_key(15u128, Chain::Ethereum));
 
-			let l2_request_id = Rolldown::get_l2_origin_updates_counter(Chain::Ethereum);
+			let l2_request_id = Rolldown::get_next_l2_request_id(Chain::Ethereum);
 			Rolldown::cancel_requests_from_l1(
 				RuntimeOrigin::signed(BOB),
 				consts::CHAIN,
@@ -1293,7 +1293,7 @@ fn test_cancel_resolution_updates_awaiting_cancel_resolution() {
 				.with_requests(vec![L1UpdateRequest::Deposit(Default::default())])
 				.build();
 
-			let l2_request_id = Rolldown::get_l2_origin_updates_counter(Chain::Ethereum);
+			let l2_request_id = Rolldown::get_next_l2_request_id(Chain::Ethereum);
 
 			let cancel_resolution = L1UpdateBuilder::default()
 				.with_requests(vec![L1UpdateRequest::CancelResolution(
@@ -1981,35 +1981,6 @@ fn test_period_based_batch_respects_sized_batches() {
 		});
 }
 
-#[test]
-#[serial]
-fn test_create_manual_batch_fails_for_wrong_range() {
-	ExtBuilder::new()
-		.issue(ALICE, ETH_TOKEN_ADDRESS_MGX, MILLION)
-		.execute_with_default_mocks(|| {
-			forward_to_block::<Test>(10);
-
-			assert_err!(
-				Rolldown::create_batch(RuntimeOrigin::signed(ALICE), consts::CHAIN, (5, 1), None),
-				Error::<Test>::InvalidRange
-			);
-		})
-}
-
-#[test]
-#[serial]
-fn test_create_manual_batch_fails_for_range_that_does_not_exists() {
-	ExtBuilder::new()
-		.issue(ALICE, ETH_TOKEN_ADDRESS_MGX, MILLION)
-		.execute_with_default_mocks(|| {
-			forward_to_block::<Test>(10);
-
-			assert_err!(
-				Rolldown::create_batch(RuntimeOrigin::signed(ALICE), consts::CHAIN, (1, 1), None),
-				Error::<Test>::NonExistingRequestId
-			);
-		})
-}
 
 #[test]
 #[serial]
@@ -2030,7 +2001,6 @@ fn test_create_manual_batch_works() {
 			assert_ok!(Rolldown::create_batch(
 				RuntimeOrigin::signed(ALICE),
 				consts::CHAIN,
-				(1, 1),
 				None
 			));
 			assert_event_emitted!(Event::TxBatchCreated {
@@ -2053,7 +2023,6 @@ fn test_create_manual_batch_works() {
 			assert_ok!(Rolldown::create_batch(
 				RuntimeOrigin::signed(ALICE),
 				consts::CHAIN,
-				(1, 1),
 				None
 			));
 			assert_event_emitted!(Event::TxBatchCreated {
@@ -2061,22 +2030,7 @@ fn test_create_manual_batch_works() {
 				source: BatchSource::Manual,
 				assignee: ALICE,
 				batch_id: 2,
-				range: (1, 1),
-			});
-
-			assert_ok!(Rolldown::create_batch(
-				RuntimeOrigin::signed(ALICE),
-				consts::CHAIN,
-				(1, 2),
-				None
-			));
-
-			assert_event_emitted!(Event::TxBatchCreated {
-				chain: consts::CHAIN,
-				source: BatchSource::Manual,
-				assignee: ALICE,
-				batch_id: 3,
-				range: (1, 2),
+				range: (2, 2),
 			});
 		})
 }
@@ -2107,7 +2061,6 @@ fn test_create_manual_batch_fails_for_invalid_alias_account() {
 				Rolldown::create_batch(
 					RuntimeOrigin::signed(BOB),
 					consts::CHAIN,
-					(1, 1),
 					Some(ALICE)
 				),
 				Error::<Test>::UnknownAliasAccount
@@ -2137,7 +2090,7 @@ fn test_create_manual_batch_work_for_alias_account() {
 			)
 			.unwrap();
 
-			Rolldown::create_batch(RuntimeOrigin::signed(BOB), consts::CHAIN, (1, 1), Some(ALICE))
+			Rolldown::create_batch(RuntimeOrigin::signed(BOB), consts::CHAIN, Some(ALICE))
 				.unwrap();
 			assert_event_emitted!(Event::TxBatchCreated {
 				chain: consts::CHAIN,
@@ -2196,7 +2149,31 @@ fn test_manual_batch_fee_update() {
 
 #[test]
 #[serial]
-fn do_not_allow_for_batches_with_gaps() {
+fn do_not_allow_for_batches_when_there_are_no_pending_requests() {
+	ExtBuilder::new()
+		.issue(ALICE, ETH_TOKEN_ADDRESS_MGX, MILLION)
+		.issue(BOB, ETH_TOKEN_ADDRESS_MGX, MILLION)
+		.execute_with_default_mocks(|| {
+			let selected_sequencer_mock =
+				MockSequencerStakingProviderApi::is_active_sequencer_alias_context();
+			selected_sequencer_mock.expect().return_const(true);
+
+			forward_to_block::<Test>(10);
+
+			assert_err!(
+				Rolldown::create_batch(
+					RuntimeOrigin::signed(BOB),
+					consts::CHAIN,
+					None,
+				),
+				Error::<Test>::EmptyBatch
+			);
+		})
+}
+
+#[test]
+#[serial]
+fn do_not_allow_for_batches_when_there_are_no_pending_requests2() {
 	ExtBuilder::new()
 		.issue(ALICE, ETH_TOKEN_ADDRESS_MGX, MILLION)
 		.issue(BOB, ETH_TOKEN_ADDRESS_MGX, MILLION)
@@ -2218,16 +2195,19 @@ fn do_not_allow_for_batches_with_gaps() {
 				.unwrap();
 			}
 
-			Rolldown::create_batch(RuntimeOrigin::signed(BOB), consts::CHAIN, (1, 5), Some(ALICE))
-				.unwrap();
+			Rolldown::create_batch(
+				RuntimeOrigin::signed(BOB),
+				consts::CHAIN,
+				None,
+			).unwrap();
+
 			assert_err!(
 				Rolldown::create_batch(
 					RuntimeOrigin::signed(BOB),
 					consts::CHAIN,
-					(7, 10),
-					Some(ALICE)
+					None,
 				),
-				Error::<Test>::InvalidRange
+				Error::<Test>::EmptyBatch
 			);
 		})
 }

--- a/pallets/rolldown/src/tests.rs
+++ b/pallets/rolldown/src/tests.rs
@@ -1927,7 +1927,8 @@ fn test_batch_is_created_automatically_when_MerkleRootAutomaticBatchPeriod_passe
 
 #[test]
 #[serial]
-fn test_batch_is_created_automatically_whenever_new_request_is_created_and_time_from_last_batch_is_greater_than_configurable_period() {
+fn test_batch_is_created_automatically_whenever_new_request_is_created_and_time_from_last_batch_is_greater_than_configurable_period(
+) {
 	ExtBuilder::new()
 		.issue(ALICE, ETH_TOKEN_ADDRESS_MGX, MILLION)
 		.build()
@@ -1959,7 +1960,10 @@ fn test_batch_is_created_automatically_whenever_new_request_is_created_and_time_
 			.unwrap();
 
 			forward_to_block::<Test>((Rolldown::automatic_batch_period() + 2u128) as u64);
-			assert_eq!(L2RequestsBatchLast::<Test>::get().get(&consts::CHAIN), Some(&((Rolldown::automatic_batch_period() + 2u128) as u64, 1u128, (1u128, 1u128))));
+			assert_eq!(
+				L2RequestsBatchLast::<Test>::get().get(&consts::CHAIN),
+				Some(&((Rolldown::automatic_batch_period() + 2u128) as u64, 1u128, (1u128, 1u128)))
+			);
 			assert_event_emitted!(Event::TxBatchCreated {
 				chain: consts::CHAIN,
 				source: BatchSource::PeriodReached,
@@ -1967,7 +1971,6 @@ fn test_batch_is_created_automatically_whenever_new_request_is_created_and_time_
 				batch_id: 1,
 				range: (1, 1),
 			});
-
 		});
 }
 
@@ -2029,7 +2032,6 @@ fn test_period_based_batch_respects_sized_batches() {
 		});
 }
 
-
 #[test]
 #[serial]
 fn test_create_manual_batch_works() {
@@ -2046,11 +2048,7 @@ fn test_create_manual_batch_works() {
 				1_000u128,
 			)
 			.unwrap();
-			assert_ok!(Rolldown::create_batch(
-				RuntimeOrigin::signed(ALICE),
-				consts::CHAIN,
-				None
-			));
+			assert_ok!(Rolldown::create_batch(RuntimeOrigin::signed(ALICE), consts::CHAIN, None));
 			assert_event_emitted!(Event::TxBatchCreated {
 				chain: consts::CHAIN,
 				source: BatchSource::Manual,
@@ -2068,11 +2066,7 @@ fn test_create_manual_batch_works() {
 			)
 			.unwrap();
 
-			assert_ok!(Rolldown::create_batch(
-				RuntimeOrigin::signed(ALICE),
-				consts::CHAIN,
-				None
-			));
+			assert_ok!(Rolldown::create_batch(RuntimeOrigin::signed(ALICE), consts::CHAIN, None));
 			assert_event_emitted!(Event::TxBatchCreated {
 				chain: consts::CHAIN,
 				source: BatchSource::Manual,
@@ -2106,11 +2100,7 @@ fn test_create_manual_batch_fails_for_invalid_alias_account() {
 			.unwrap();
 
 			assert_err!(
-				Rolldown::create_batch(
-					RuntimeOrigin::signed(BOB),
-					consts::CHAIN,
-					Some(ALICE)
-				),
+				Rolldown::create_batch(RuntimeOrigin::signed(BOB), consts::CHAIN, Some(ALICE)),
 				Error::<Test>::UnknownAliasAccount
 			);
 		})
@@ -2138,8 +2128,7 @@ fn test_create_manual_batch_work_for_alias_account() {
 			)
 			.unwrap();
 
-			Rolldown::create_batch(RuntimeOrigin::signed(BOB), consts::CHAIN, Some(ALICE))
-				.unwrap();
+			Rolldown::create_batch(RuntimeOrigin::signed(BOB), consts::CHAIN, Some(ALICE)).unwrap();
 			assert_event_emitted!(Event::TxBatchCreated {
 				chain: consts::CHAIN,
 				source: BatchSource::Manual,
@@ -2209,11 +2198,7 @@ fn do_not_allow_for_batches_when_there_are_no_pending_requests() {
 			forward_to_block::<Test>(10);
 
 			assert_err!(
-				Rolldown::create_batch(
-					RuntimeOrigin::signed(BOB),
-					consts::CHAIN,
-					None,
-				),
+				Rolldown::create_batch(RuntimeOrigin::signed(BOB), consts::CHAIN, None,),
 				Error::<Test>::EmptyBatch
 			);
 		})
@@ -2243,23 +2228,14 @@ fn do_not_allow_for_batches_when_there_are_no_pending_requests2() {
 				.unwrap();
 			}
 
-			Rolldown::create_batch(
-				RuntimeOrigin::signed(BOB),
-				consts::CHAIN,
-				None,
-			).unwrap();
+			Rolldown::create_batch(RuntimeOrigin::signed(BOB), consts::CHAIN, None).unwrap();
 
 			assert_err!(
-				Rolldown::create_batch(
-					RuntimeOrigin::signed(BOB),
-					consts::CHAIN,
-					None,
-				),
+				Rolldown::create_batch(RuntimeOrigin::signed(BOB), consts::CHAIN, None,),
 				Error::<Test>::EmptyBatch
 			);
 		})
 }
-
 
 #[test]
 #[serial]
@@ -2269,7 +2245,6 @@ fn manual_batches_not_allowed_in_maintanance_mode() {
 		.issue(BOB, ETH_TOKEN_ADDRESS_MGX, MILLION)
 		.build()
 		.execute_with(|| {
-
 			let is_maintenance_mock = MockMaintenanceStatusProviderApi::is_maintenance_context();
 			is_maintenance_mock.expect().return_const(false);
 
@@ -2284,7 +2259,7 @@ fn manual_batches_not_allowed_in_maintanance_mode() {
 				ETH_RECIPIENT_ACCOUNT,
 				ETH_TOKEN_ADDRESS,
 				1_000u128,
-				)
+			)
 			.unwrap();
 			is_maintenance_mock.checkpoint();
 
@@ -2292,11 +2267,7 @@ fn manual_batches_not_allowed_in_maintanance_mode() {
 			is_maintenance_mock.expect().return_const(true);
 
 			assert_err!(
-				Rolldown::create_batch(
-					RuntimeOrigin::signed(BOB),
-					consts::CHAIN,
-					None,
-				),
+				Rolldown::create_batch(RuntimeOrigin::signed(BOB), consts::CHAIN, None,),
 				Error::<Test>::BlockedByMaintenanceMode
 			);
 		})
@@ -2327,7 +2298,7 @@ fn automatic_batches_triggered_by_period_blocked_maintenance_mode() {
 				ETH_RECIPIENT_ACCOUNT,
 				ETH_TOKEN_ADDRESS,
 				1_000u128,
-				)
+			)
 			.unwrap();
 			is_maintenance_mock.checkpoint();
 
@@ -2365,7 +2336,7 @@ fn automatic_batches_triggered_by_pending_requests_blocked_maintenance_mode() {
 					ETH_RECIPIENT_ACCOUNT,
 					ETH_TOKEN_ADDRESS,
 					1_000u128,
-					)
+				)
 				.unwrap();
 			}
 			is_maintenance_mock.checkpoint();
@@ -2376,7 +2347,6 @@ fn automatic_batches_triggered_by_pending_requests_blocked_maintenance_mode() {
 			assert_eq!(L2RequestsBatchLast::<Test>::get().get(&consts::CHAIN), None);
 		})
 }
-
 
 #[test]
 #[serial]
@@ -2396,11 +2366,9 @@ fn test_withdrawals_are_not_allowed_in_maintanance_mode() {
 					ETH_RECIPIENT_ACCOUNT,
 					ETH_TOKEN_ADDRESS,
 					1_000u128,
-					)
-				,
+				),
 				Error::<Test>::BlockedByMaintenanceMode
 			);
-
 		})
 }
 
@@ -2437,8 +2405,6 @@ fn test_cancels_are_not_allowed_in_maintanance_mode() {
 				),
 				Error::<Test>::BlockedByMaintenanceMode
 			);
-
-
 		})
 }
 
@@ -2467,7 +2433,5 @@ fn test_updates_are_not_allowed_in_maintanance_mode() {
 				Rolldown::update_l2_from_l1(RuntimeOrigin::signed(ALICE), deposit_update),
 				Error::<Test>::BlockedByMaintenanceMode
 			);
-
-
 		})
 }


### PR DESCRIPTION
Changes:
- `EmptyBatch` error is triggered when someone wants to create batch manually but there are no requests to put into the batch(no new requests since last batch was created)
- Rolldown pallet functionality is limited when `MaintenanceMode` is on. Cancels, updates, withdrawals and manual batch creation fails with `BlockedByMaintananceMode` error
- Automatic batches are not formed in Maintanence mode

- **[MGX-1370] Align manual batches**
- **Test for specific behaviour agreed with product team**
- **[MGX-1366] - BEX - Maintanance mode alignments**


[MGX-1370]: https://mangatafinance.atlassian.net/browse/MGX-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MGX-1366]: https://mangatafinance.atlassian.net/browse/MGX-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ