### PR TITLE
add multiswap_asset as a proxy type...

### DIFF
--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -1456,6 +1456,7 @@ where
 		)]
 		pub enum ProxyType {
 			AutoCompound,
+			MultiswapAsset
 		}
 
 		impl Default for ProxyType {
@@ -1463,6 +1464,8 @@ where
 				Self::AutoCompound
 			}
 		}
+
+		
 
 		parameter_types! {
 			pub const ProxyDepositBase: Balance = deposit(1, 16);

--- a/runtime/mangata-kusama/src/lib.rs
+++ b/runtime/mangata-kusama/src/lib.rs
@@ -676,6 +676,14 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 						RuntimeCall::Xyk(pallet_xyk::Call::compound_rewards { .. })
 				)
 			},
+			// MultiswapAsset proxy type
+            ProxyType::MultiswapAsset => {
+                matches!(
+                    c,
+                    RuntimeCall::Xyk(pallet_xyk::Call::multiswap_buy_asset { .. })
+                        | RuntimeCall::Xyk(pallet_xyk::Call::multiswap_sell_asset { .. })
+                )
+            },
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {

--- a/runtime/mangata-rococo/src/lib.rs
+++ b/runtime/mangata-rococo/src/lib.rs
@@ -703,6 +703,14 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 						RuntimeCall::Xyk(pallet_xyk::Call::compound_rewards { .. })
 				)
 			},
+			// MultiswapAsset proxy type
+            ProxyType::MultiswapAsset => {
+                matches!(
+                    c,
+                    RuntimeCall::Xyk(pallet_xyk::Call::multiswap_buy_asset { .. })
+                        | RuntimeCall::Xyk(pallet_xyk::Call::multiswap_sell_asset { .. })
+                )
+            },
 		}
 	}
 	fn is_superset(&self, o: &Self) -> bool {


### PR DESCRIPTION
This is so that we can execute xcm calls from sibling chains, specficially Turing chain, which allows for scheduling xcm calls at a later date and/or recurring.

Currently there is only AutoCompound as a ProxyType. But with MultiswapAsset other chains can execute a mangata based swap from their chian. 