### PR TITLE
CI: Add additionoal unlocked runtime image build in CI

### DIFF
--- a/.github/workflows/reusable-build-and-test.yml
+++ b/.github/workflows/reusable-build-and-test.yml
@@ -135,7 +135,52 @@ jobs:
 
             SECONDS=0; gcloud storage cp "$ARCHIVE_NAME" "gs://mangata-node-ci-cache/$CACHE_KEY/$ARCHIVE_NAME"
             echo "Upload completed in $SECONDS seconds"
-
+  
+  create-docker-image-manifest-and-export-wasms:
+    name: Generate multiplatform Docker image manifest
+    needs: [build-node-image]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+  
+      - uses: docker/setup-buildx-action@v3
+      - run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+  
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}
+          tags: |
+            type=raw,value=${{ inputs.version }}
+            type=raw,value=${{ inputs.branch }}
+  
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}@sha256:%s ' *)
+  
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}:${{ steps.meta.outputs.version }}
+  
+      - name: Export WASM artifacts from built images
+        run: |
+          # Export WASM artifact from image with regular runtime
+          container_id=$(docker create ${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}:${{ inputs.version }}) && \
+            docker cp $container_id:/app/rollup_runtime.compact.compressed.wasm ./rollup_runtime-${{ inputs.version }}.compact.compressed.wasm && \
+            docker rm $container_id
+  
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wasm-${{ inputs.version }}
+          path: ./rollup_runtime-${{ inputs.version }}.compact.compressed.wasm
+    
   build-node-image-with-fast-runtime:
     name: Build fast runtime Docker image
     strategy:
@@ -236,51 +281,6 @@ jobs:
             SECONDS=0; gcloud storage cp "$ARCHIVE_NAME" "gs://mangata-node-ci-cache/$CACHE_KEY/$ARCHIVE_NAME"
             echo "Upload completed in $SECONDS seconds"
 
-  create-docker-image-manifest-and-export-wasms:
-    name: Generate multiplatform Docker image manifest
-    needs: [build-node-image]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - uses: docker/setup-buildx-action@v3
-      - run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}
-          tags: |
-            type=raw,value=${{ inputs.version }}
-            type=raw,value=${{ inputs.branch }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}@sha256:%s ' *)
-
-      - name: Inspect image
-        run: docker buildx imagetools inspect ${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}:${{ steps.meta.outputs.version }}
-
-      - name: Export WASM artifacts from built images
-        run: |
-          # Export WASM artifact from image with regular runtime
-          container_id=$(docker create ${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}:${{ inputs.version }}) && \
-            docker cp $container_id:/app/rollup_runtime.compact.compressed.wasm ./rollup_runtime-${{ inputs.version }}.compact.compressed.wasm && \
-            docker rm $container_id
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: wasm-${{ inputs.version }}
-          path: ./rollup_runtime-${{ inputs.version }}.compact.compressed.wasm
-
   create-fast-docker-image-manifest-and-export-wasms:
     name: Generate multiplatform Docker image manifest for fast runtime image
     needs: [build-node-image-with-fast-runtime]
@@ -292,10 +292,10 @@ jobs:
           path: /tmp/digests
           pattern: fast-digests-*
           merge-multiple: true
-
+  
       - uses: docker/setup-buildx-action@v3
       - run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
-
+  
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -304,16 +304,16 @@ jobs:
           tags: |
             type=raw,value=${{ inputs.version }}-fast
             type=raw,value=${{ inputs.branch }}-fast
-
+  
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}@sha256:%s ' *)
-
+  
       - name: Inspect image
         run: docker buildx imagetools inspect ${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}:${{ steps.meta.outputs.version }}
-
+  
       - name: Export WASM artifacts from built images
         run: |
           # Export WASM artifact from image with fast runtime
@@ -324,6 +324,150 @@ jobs:
         with:
           name: wasm-fast-${{ inputs.version }}
           path: ./rollup_runtime-${{ inputs.version }}-fast.compact.compressed.wasm
+  
+  build-node-image-with-unlocked-runtime:
+    name: Build unlocked runtime Docker image
+    strategy:
+      matrix:
+        platform:
+          - name: amd64
+            runner: compile-gke
+          - name: arm64
+            runner: compile-gke-arm
+    runs-on: ${{ matrix.platform.runner }}
+    env:
+      JOB_CACHE_PREFIX: docker-buildx-unlocked-cache-${{ matrix.platform.name }}-${{ inputs.cache-version }}
+      CACHE_ARCHIVE_NAME: cache_archive.tar.zst
+    steps:
+      - uses: actions/checkout@v4
+  
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}
+          labels: |
+            runtime-type=unlocked
+  
+      - uses: docker/setup-buildx-action@v3
+      - run: curl -LJO https://github.com/reproducible-containers/buildkit-cache-dance/archive/refs/tags/v3.1.2.tar.gz && tar xvf buildkit-cache-dance-3.1.2.tar.gz
+      - run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+  
+      - uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - uses: google-github-actions/setup-gcloud@v2
+  
+      - name: Download cargo build cache
+        if: inputs.cache-enabled
+        id: cache
+        run: |
+          set -x
+          CACHE_KEY="${{ env.JOB_CACHE_PREFIX }}-${{ hashFiles('**/Cargo.lock') }}"
+          ARCHIVE_NAME="${{ env.CACHE_ARCHIVE_NAME }}"
+          CACHE_FOUND=false
+  
+          if gcloud storage cp "gs://mangata-node-ci-cache/$CACHE_KEY/$ARCHIVE_NAME" - | zstd -d | tar -xf - ; then
+            echo "Injecting buildkit mount cache into Docker system"
+            node ./buildkit-cache-dance-3.1.2/dist/index.js --cache-map '{"usr-local-cargo-registry": "/usr/local/cargo/registry", "usr-local-cargo-git": "/usr/local/cargo/git", "app-target": "/app/target"}'
+  
+            CACHE_FOUND=true
+          fi
+  
+          echo "cache_found=$CACHE_FOUND" >> $GITHUB_OUTPUT
+          echo "cache_key=$CACHE_KEY" >> $GITHUB_OUTPUT
+  
+      - name: Build and export unlocked runtime image by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          build-args: "ENABLE_UNLOCKED_RUNTIME=true"
+          platforms: linux/${{ matrix.platform.name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.NODE_DOCKER_IMAGE_REPOSITORY }},push-by-digest=true,name-canonical=true,push=true
+  
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+  
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: unlocked-digests-linux-${{ matrix.platform.name }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  
+      - name: Upload cargo build cache
+        if: inputs.cache-enabled && steps.cache.outputs.cache_found == 'false'
+        shell: bash
+        run: |
+          set -x
+  
+          echo "Extracting buildkit cache from Docker system"
+          node ./buildkit-cache-dance-3.1.2/dist/index.js --extract --cache-map '{"usr-local-cargo-registry": "/usr/local/cargo/registry", "usr-local-cargo-git": "/usr/local/cargo/git", "app-target": "/app/target"}'
+  
+          CACHE_KEY="${{ steps.cache.outputs.cache_key }}"
+          ARCHIVE_NAME="${{ env.CACHE_ARCHIVE_NAME }}"
+          CACHE_PATHS=(
+            "usr-local-cargo-registry"
+            "usr-local-cargo-git"
+            "app-target"
+          )
+  
+            SECONDS=0; tar -cf - "${CACHE_PATHS[@]}" | zstd -T0 -5 > "$ARCHIVE_NAME"
+            echo "Compression completed in $SECONDS seconds" && echo "Archive size: $(du -h "$ARCHIVE_NAME" | cut -f1)"
+  
+            SECONDS=0; gcloud storage cp "$ARCHIVE_NAME" "gs://mangata-node-ci-cache/$CACHE_KEY/$ARCHIVE_NAME"
+            echo "Upload completed in $SECONDS seconds"
+
+  create-unlocked-runtime-docker-image-manifest-and-export-wasms:
+    name: Generate multiplatform Docker image manifest for unlocked runtime image
+    needs: [build-node-image-with-unlocked-runtime]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: unlocked-digests-*
+          merge-multiple: true
+  
+      - uses: docker/setup-buildx-action@v3
+      - run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+  
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}
+          tags: |
+            type=raw,value=${{ inputs.version }}-unlocked
+            type=raw,value=${{ inputs.branch }}-unlocked
+  
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}@sha256:%s ' *)
+  
+      - name: Inspect image
+        run: docker buildx imagetools inspect ${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}:${{ steps.meta.outputs.version }}
+  
+      - name: Export WASM artifacts from built images
+        run: |
+          # Export WASM artifact from image with unlocked runtime
+          container_id_unlocked=$(docker create ${{ env.NODE_DOCKER_IMAGE_REPOSITORY }}:${{ inputs.version }}-unlocked) && \
+            docker cp $container_id_unlocked:/app/rollup_runtime.compact.compressed.wasm ./rollup_runtime-${{ inputs.version }}-unlocked.compact.compressed.wasm && \
+            docker rm $container_id_unlocked
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wasm-unlocked-${{ inputs.version }}
+          path: ./rollup_runtime-${{ inputs.version }}-unlocked.compact.compressed.wasm            
 
   rustfmt-check:
     name: Formatting check

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY . .
 
 ARG ENABLE_FAST_RUNTIME=false
+ARG ENABLE_UNLOCKED_RUNTIME=false
 
 # Set RUSTC_WRAPPER to empty string by default, as it's causing random issues on arm64 image builds in CI
 # To enable sccache set RUSTC_WRAPPER build arg to "sccache" in your image build command with `--build-arg RUSTC_WRAPPER=sccache`
@@ -16,6 +17,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     export RUSTC_WRAPPER=${RUSTC_WRAPPER} && \
     if [ "$ENABLE_FAST_RUNTIME" = "true" ]; then \
         cargo build --release --no-default-features --features=fast-runtime; \
+    elif [ "$ENABLE_UNLOCKED_RUNTIME" = "true" ]; then \
+        cargo build --release --no-default-features --features=unlocked; \
     else \
         cargo build --locked --release; \
     fi \


### PR DESCRIPTION
Introduce a separate build process for Docker images with an unlocked runtime, along with the necessary adjustments to export WASM artifacts and manage image manifests.