### PR TITLE
fixes gasp-1666 gasp-1671

### DIFF
--- a/pallets/rolldown/src/mock.rs
+++ b/pallets/rolldown/src/mock.rs
@@ -155,6 +155,7 @@ impl rolldown::Config for Test {
 	type SequencerStakingRewards = ();
 	type WithdrawFee = ConvertToValue<ConstU128<500>>;
 	type WeightInfo = ();
+	type NontransferableTokens = Nothing;
 }
 
 pub struct ExtBuilder {

--- a/rollup/runtime/src/lib.rs
+++ b/rollup/runtime/src/lib.rs
@@ -794,6 +794,7 @@ impl pallet_rolldown::Config for Runtime {
 	type SequencerStakingRewards = SequencerStaking;
 	type WithdrawFee = cfg::pallet_rolldown::WithdrawFee;
 	type WeightInfo = weights::pallet_rolldown::ModuleWeight<Runtime>;
+	type NontransferableTokens = tokens::NontransferableTokens;
 }
 
 impl pallet_rolldown::RolldownBenchmarkingConfig for Runtime {}


### PR DESCRIPTION
limit withdrawals recipient to sender's address for nontransferable tokens
ensure withdraw amount >= ferry tip